### PR TITLE
fix: rewards btn should be disabled when claimed

### DIFF
--- a/pages/quest/[questPage].tsx
+++ b/pages/quest/[questPage].tsx
@@ -109,10 +109,7 @@ const QuestPage: NextPage = () => {
       fetch(`${quest.rewards_endpoint}?addr=${hexToDecimal(address)}`)
         .then((response) => response.json())
         .then((data) => {
-          if (!data.rewards) {
-            setRewardsEnabled(false);
-          } else {
-            setRewardsEnabled(true);
+          if (data.rewards) {
             setEligibleRewards(splitByNftContract(data.rewards));
           }
         });
@@ -169,6 +166,8 @@ const QuestPage: NextPage = () => {
         ],
       });
     });
+    if (unclaimedRewards) setRewardsEnabled(true);
+    else setRewardsEnabled(false);
     setMintCalldata(calldata);
   }, [questId, unclaimedRewards]);
 


### PR DESCRIPTION
This should close #23 

The issue came from the fact I checked what the user could claim access to, not what he had left to clain.