### PR TITLE
feat: disable rewards when claimed

### DIFF
--- a/pages/quest/[questPage].tsx
+++ b/pages/quest/[questPage].tsx
@@ -166,8 +166,9 @@ const QuestPage: NextPage = () => {
         ],
       });
     });
-    if (unclaimedRewards) setRewardsEnabled(true);
-    else setRewardsEnabled(false);
+    if (unclaimedRewards && unclaimedRewards.length > 0) {
+      setRewardsEnabled(true);
+    } else setRewardsEnabled(false);
     setMintCalldata(calldata);
   }, [questId, unclaimedRewards]);
 


### PR DESCRIPTION
second fix, javascript behavior is different from python: if (arr) returns true if the array is empty