### PR TITLE
fix: add error msg in case profile not found

### DIFF
--- a/pages/[addressOrDomain].tsx
+++ b/pages/[addressOrDomain].tsx
@@ -49,7 +49,10 @@ const AddressOrDomain: NextPage = () => {
         ?.getStarknetId(addressOrDomain)
         .then((id) => {
           getIdentityData(id).then((data: Identity) => {
-            if (data.error) return;
+            if (data.error) {
+              setNotFound(true);
+              return;
+            }
             setIdentity({
               ...data,
               id: id.toString(),


### PR DESCRIPTION
In case name.stark domain provided in profile url does not exist, show error message "Profile not found"