### PR TITLE
fix: unclaimed rewards are deduced from eligible if sequencer fails

### DIFF
--- a/pages/quest/[questPage].tsx
+++ b/pages/quest/[questPage].tsx
@@ -193,8 +193,6 @@ const QuestPage: NextPage = () => {
         }
       }
       setUnclaimedRewards(unclaimed);
-      console.log("uclaimed:", unclaimed);
-      console.log("eligible:", eligibleRewards);
     })();
   }, [questId, eligibleRewards]);
 


### PR DESCRIPTION
If the sequencer fails to check claimed rewards, we currently don't allow the user to claim them. Here is a way to build the tx optimistically by considering the eligible rewards as unclaimed. If that's not the case (i.e. a user already claimed his reward AND is blacklisted by the sequencer), he will see the claim rewards button, but the tx won't pass. So we improve the user experience of most of our users at the price of decreasing a lil bit the one of users trying to dupe their rewards. Hopefully there is no security issue as the tx won't be accepted by the contract.