### PR TITLE
fix: convert hex address to decimal to support new backend

### DIFF
--- a/pages/[addressOrDomain].tsx
+++ b/pages/[addressOrDomain].tsx
@@ -146,7 +146,7 @@ const AddressOrDomain: NextPage = () => {
                       ...data,
                       starknet_id: id.toString(),
                     });
-                    if (hexToDecimal(address) === data.addr) setIsOwner(true);
+                    if (hexToDecimal(address) === hexToDecimal(data.addr)) setIsOwner(true);
                     setInitProfile(true);
                   });
                 })


### PR DESCRIPTION
To support new starknetid backend we need to support hex addresses returned by the backend (so convert it to decimal). 