### PR TITLE
fix: use starknetid.js instead of calling indexer

### DIFF
--- a/hooks/useHasRootDomain.ts
+++ b/hooks/useHasRootDomain.ts
@@ -1,18 +1,16 @@
 import BN from "bn.js";
 import { useContext, useEffect, useState } from "react";
 import { StarknetIdJsContext } from "../context/StarknetIdJsProvider";
-import { hexToDecimal } from "../utils/feltService";
+import { utils } from "starknetid.js";
 
 export default function useHasRootDomain(address: string | BN | undefined) {
   const [hasRootDomain, setHasRootDomain] = useState(false);
   const { starknetIdNavigator } = useContext(StarknetIdJsContext);
   useEffect(() => {
     if (!address) return;
-    fetch(
-      `${
-        process.env.NEXT_PUBLIC_STARKNET_ID_API_LINK
-      }/addr_to_domain?addr=${hexToDecimal(address.toString())}`
-    ).then((res) => res.status === 200 && setHasRootDomain(true));
+    starknetIdNavigator?.getStarkName(address.toString()).then((res) => {
+      if (utils.isStarkRootDomain(res)) setHasRootDomain(true);
+    });
   }, [starknetIdNavigator, address]);
 
   return hasRootDomain;


### PR DESCRIPTION
At the moment it seems that for some addresses both apis are not returning any results for some addresses when calling `addr_to_domain`, this PR uses starknetid.js instead. 