### PR TITLE
fix: pass connectors as any in app.tsx

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -44,7 +44,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   });
 
   return (
-    <StarknetConfig connectors={connectors} autoConnect>
+    <StarknetConfig connectors={connectors as any} autoConnect>
       <StarknetIdJsProvider>
         <ThemeProvider theme={theme}>
           <Head>


### PR DESCRIPTION
It types `connectors` as `any` in app.tsx otherwise it creates a build error in the prod build.