### PR TITLE
feat: add cdn image components

### DIFF
--- a/app/partnership/page.tsx
+++ b/app/partnership/page.tsx
@@ -15,6 +15,7 @@ import Blur from "../../components/shapes/blur";
 import Card from "../../components/UI/card";
 import team from "../../public/starknetid/team.json";
 import TwitterIcon from "../../components/UI/iconsComponents/icons/twitterIcon";
+import { CDNImg } from "../../components/cdn/image";
 
 export default function Page() {
   useEffect(() => {
@@ -51,7 +52,7 @@ export default function Page() {
             <Cross />
           </div>
           <div className={`${styles.divider} ${styles.dividerGradient}`} />
-          <img src="/utils/headerDivider.svg" className={styles.divider} />
+          <CDNImg src="/utils/headerDivider.svg" className={styles.divider} />
         </header>
         <main className={styles.main}>
           <section className={styles.section}>
@@ -154,11 +155,11 @@ export default function Page() {
                 title="They worked with us"
               />
               <div className={styles.partnersContainer}>
-                <img src="/partners/braavosLogo.svg" />
-                <img src="/partners/zklendLogo.svg" />
-                <img src="/partners/sithswapLogo.svg" />
-                <img src="/partners/jediswapLogo.svg" />
-                <img src="/partners/avnuLogo.svg" />
+                <CDNImg src="/partners/braavosLogo.svg" />
+                <CDNImg src="/partners/zklendLogo.svg" />
+                <CDNImg src="/partners/sithswapLogo.svg" />
+                <CDNImg src="/partners/jediswapLogo.svg" />
+                <CDNImg src="/partners/avnuLogo.svg" />
               </div>
             </Box>
             <div className={styles.lastCrosses}>

--- a/components/UI/featured_banner/featuredQuest.tsx
+++ b/components/UI/featured_banner/featuredQuest.tsx
@@ -4,6 +4,7 @@ import Button from "../..//UI/button";
 import { useMediaQuery } from "@mui/material";
 import FeaturedQuestSkeleton from "../../skeletons/featuredQuestSkeleton";
 import Timer from "../../quests/timer";
+import { CDNImg } from "../../cdn/image";
 
 type FeaturedQuestProps = {
   onClick?: () => void;
@@ -35,7 +36,7 @@ const FeaturedQuest: FunctionComponent<FeaturedQuestProps> = ({
         <h3 className={styles.featuredQuestTitle}>{title}</h3>
         <p className="text-gray-200	 mt-4 text-start">{desc}</p>
         <div className="flex mt-4 mb-4 items-center">
-          <img width={20} src={issuer?.logoFavicon} />
+          <CDNImg width={20} src={issuer?.logoFavicon} />
           <p className="text-white ml-2">{reward}</p>
         </div>
         <div>
@@ -43,7 +44,7 @@ const FeaturedQuest: FunctionComponent<FeaturedQuestProps> = ({
         </div>
       </div>
       <div className={styles.featuredQuestImageContainer}>
-        <img src={imgSrc} className={styles.featuredQuestImage} />
+        <CDNImg src={imgSrc} className={styles.featuredQuestImage} />
         {expiry ? <Timer expiry={Number(expiry)} /> : null}
       </div>
     </div>

--- a/components/UI/menus/bannerPopup.tsx
+++ b/components/UI/menus/bannerPopup.tsx
@@ -3,6 +3,7 @@ import styles from "../../../styles/components/popup.module.css";
 import Button from "../button";
 import CloseIcon from "../iconsComponents/icons/closeIcon";
 import { Modal } from "@mui/material";
+import { CDNImg } from "../../cdn/image";
 
 type BannerPopupProps = {
   title: string;
@@ -32,7 +33,7 @@ const BannerPopup: FunctionComponent<BannerPopupProps> = ({
       <div className={styles.bannerPopup}>
         <div className={styles.titleSide}>
           <h1 className={styles.title}>{title}</h1>
-          <img className={styles.banner} src={banner} alt="banner" />
+          <CDNImg className={styles.banner} src={banner} alt="banner" />
         </div>
         <div className={styles.contentSide}>
           <button className={styles.close} onClick={onClose}></button>

--- a/components/UI/profileCards.tsx
+++ b/components/UI/profileCards.tsx
@@ -9,6 +9,7 @@ import ShareIcon from "./iconsComponents/icons/shareIcon";
 import SharePopup from "./menus/sharePopup";
 import theme from "../../styles/theme";
 import { useStarkProfile } from "@starknet-react/core";
+import { CDNImg } from "../cdn/image";
 
 const ProfileCards: FunctionComponent<ProfileCard> = ({
   title,
@@ -126,7 +127,7 @@ const ProfileCards: FunctionComponent<ProfileCard> = ({
                 if (!building.image_url) return null;
                 return (
                   <div key={building.nft_id} className={styles.nftContainer}>
-                    <img src={building.image_url} className={styles.nftImage} />
+                    <CDNImg src={building.image_url} className={styles.nftImage} />
                     <p className={styles.nftName}>{building.name}</p>
                   </div>
                 );

--- a/components/UI/steps/stepElement.tsx
+++ b/components/UI/steps/stepElement.tsx
@@ -2,6 +2,7 @@ import VerticalBar from "../../shapes/verticalBar";
 import OnScrollIntoView from "../../animations/onScrollIntoView";
 import styles from "../../../styles/components/steps.module.css";
 import React, { FunctionComponent } from "react";
+import { CDNImg } from "../../cdn/image";
 
 type StepElementProps = {
   index: number;
@@ -19,7 +20,7 @@ const StepElement: FunctionComponent<StepElementProps> = ({
   return (
     <div className={styles.cardContainer}>
       <div className={styles.barsContainer}>
-        <img className={styles.icon} src={step.icon} />
+        <CDNImg className={styles.icon} src={step.icon} />
         {index !== steps.length - 1 && (
           <div className={styles.verticalBarContainer}>
             <VerticalBar />
@@ -43,7 +44,7 @@ const StepElement: FunctionComponent<StepElementProps> = ({
             <div className={styles.overlay}>{step.overlay}</div>
           ) : null}
           <div>
-            <img className={styles.banner} src={step.banner} />
+            <CDNImg className={styles.banner} src={step.banner} />
           </div>
         </div>
       </OnScrollIntoView>

--- a/components/achievements/level.tsx
+++ b/components/achievements/level.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from "react";
 import styles from "../../styles/achievements.module.css";
 import { AchievementDocument } from "../../types/backTypes";
 import { CustomTooltip } from "../UI/tooltip";
+import { CDNImg } from "../cdn/image";
 
 type AchievementLevelProps = {
   achievement: AchievementDocument;
@@ -36,7 +37,7 @@ const AchievementLevel: FunctionComponent<AchievementLevelProps> = ({
             !achievement.completed ? styles.disabled : ""
           }`}
         >
-          <img src={achievement.img_url} alt="achievement level image" />
+          <CDNImg src={achievement.img_url} alt="achievement level image" />
         </div>
       </div>
     </CustomTooltip>

--- a/components/cdn/image.tsx
+++ b/components/cdn/image.tsx
@@ -1,0 +1,36 @@
+import Image, { ImageProps, StaticImageData } from "next/image";
+import React, { ImgHTMLAttributes } from "react";
+
+export const CDNImg: React.FC<ImgHTMLAttributes<HTMLImageElement>> = ({
+  src,
+  ...props
+}) => {
+  const fullPath =
+    process.env.NODE_ENV === "development" && src && src.startsWith("/")
+      ? `${process.env.NEXT_PUBLIC_CDN_URL}${src}`
+      : src;
+
+  return <img src={fullPath} {...props} />;
+};
+
+type ImageSrc = string | StaticImageData;
+
+interface CDNImageProps extends Omit<ImageProps, "src"> {
+  src: ImageSrc;
+}
+
+export const CDNImage: React.FC<CDNImageProps> = ({ src, ...props }) => {
+  let imagePath: string;
+
+  if (typeof src === "string") {
+    imagePath =
+      process.env.NODE_ENV === "development" && src.startsWith("/")
+        ? `${process.env.NEXT_PUBLIC_CDN_URL}${src}`
+        : src;
+  } else {
+    // if src is not an URL, we can't use the CDN
+    imagePath = src.src;
+  }
+
+  return <Image src={imagePath} {...props} />;
+};

--- a/components/leaderboard/ControlsDashboard.tsx
+++ b/components/leaderboard/ControlsDashboard.tsx
@@ -1,10 +1,9 @@
 import React, { FunctionComponent, useMemo, useState } from "react";
-import BottomArrow from "../../public/icons/dropdownArrow.svg";
-import Image from "next/image";
 import { PAGE_SIZE, timeFrameMap } from "../../utils/constants";
 import styles from "../../styles/leaderboard.module.css";
 import ChevronLeftIcon from "../UI/iconsComponents/icons/chevronLeftIcon";
 import ChevronRightIcon from "../UI/iconsComponents/icons/ChevronRightIcon";
+import { CDNImage } from "../cdn/image";
 
 // this will contain the pagination arrows and page size limit controls
 const ControlsDashboard: FunctionComponent<ControlsDashboardProps> = ({
@@ -63,7 +62,11 @@ const ControlsDashboard: FunctionComponent<ControlsDashboardProps> = ({
         >
           <div className={styles.controls_option_display}>
             <p>{rowsPerPage}</p>
-            <Image src={BottomArrow} priority alt="Arrow icon" />
+            <CDNImage
+              src={"/icons/dropdownArrow.svg"}
+              priority
+              alt="Arrow icon"
+            />
           </div>
           {showMenu ? (
             <div className={styles.pages_menu}>

--- a/components/leaderboard/RankCard.tsx
+++ b/components/leaderboard/RankCard.tsx
@@ -1,14 +1,12 @@
 import React, { FunctionComponent, useEffect, useState } from "react";
 import styles from "../../styles/leaderboard.module.css";
-import Image from "next/image";
 import { minifyAddress } from "../../utils/stringService";
-import Trophy from "../../public/icons/trophy.svg";
-import XpBadge from "../../public/icons/xpBadge.svg";
 import Avatar from "../UI/avatar";
 import { decimalToHex } from "../../utils/feltService";
 import { getDomainFromAddress } from "../../utils/domainService";
 import Divider from "@mui/material/Divider";
 import AchievementIcon from "../UI/iconsComponents/icons/achievementIcon";
+import { CDNImage } from "../cdn/image";
 
 type RankCardProps = {
   name: string;
@@ -69,12 +67,12 @@ const RankCard: FunctionComponent<RankCardProps> = ({
 
       <div className={styles.rank_card_numbers}>
         <div className={styles.rank_card_number_layout}>
-          <Image src={XpBadge} priority width={30} height={30} alt="xp badge" />
+          <CDNImage src={"/icons/xpBadge.svg"} priority width={30} height={30} alt="xp badge" />
           <p>{experience}</p>
         </div>
         <div className={styles.rank_card_number_layout}>
-          <Image
-            src={Trophy}
+          <CDNImage
+            src={"/icons/trophy.svg"}
             priority
             width={30}
             height={30}

--- a/components/leaderboard/RankingsTable.tsx
+++ b/components/leaderboard/RankingsTable.tsx
@@ -4,14 +4,13 @@ import { minifyAddress, minifyDomain } from "../../utils/stringService";
 import { getDomainFromAddress } from "../../utils/domainService";
 import { decimalToHex } from "../../utils/feltService";
 import Avatar from "../UI/avatar";
-import XpBadge from "../../public/icons/xpBadge.svg";
 import { FunctionComponent, useEffect, useState } from "react";
 import { getCompletedQuestsOfUser } from "../../services/apiService";
 import styles from "../../styles/leaderboard.module.css";
-import Image from "next/image";
 import { useMediaQuery } from "@mui/material";
 import { isStarkDomain } from "starknetid.js/packages/core/dist/utils";
 import Link from "next/link";
+import { CDNImage } from "../cdn/image";
 
 // show leaderboard ranking table
 const RankingsTable: FunctionComponent<RankingProps> = ({
@@ -107,8 +106,8 @@ const RankingsTable: FunctionComponent<RankingProps> = ({
               </div>
               <div className={styles.ranking_table_row_xp_quest}>
                 <div className={styles.ranking_points_layout}>
-                  <Image
-                    src={XpBadge}
+                  <CDNImage
+                    src={"/icons/xpBadge.svg"}
                     priority
                     width={35}
                     height={35}

--- a/components/leaderboard/searchbar.tsx
+++ b/components/leaderboard/searchbar.tsx
@@ -4,10 +4,8 @@ import React, {
   useState,
   FunctionComponent,
 } from "react";
-import SearchIcon from "../../public/icons/searchIcon.svg";
 import Image from "next/image";
 import styles from "../../styles/leaderboard.module.css";
-import CrossIcon from "../../public/icons/cross.svg";
 import { StarknetIdJsContext } from "../../context/StarknetIdJsProvider";
 import { hexToDecimal } from "../../utils/feltService";
 
@@ -68,7 +66,7 @@ const Searchbar: FunctionComponent<SearchbarProps> = ({
     <div className="relative gap-2 z-50">
       <div className={styles.search_bar_container}>
         <Image
-          src={SearchIcon}
+          src={"/icons/searchIcon.svg"}
           priority
           width={16}
           height={16}
@@ -91,7 +89,7 @@ const Searchbar: FunctionComponent<SearchbarProps> = ({
             }}
           >
             <Image
-              src={CrossIcon}
+              src={"/icons/cross.svg"}
               priority
               width={20}
               height={20}

--- a/components/quests/nftImage.tsx
+++ b/components/quests/nftImage.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from "react";
 import styles from "../../styles/quests.module.css";
+import { CDNImg } from "../cdn/image";
 
 type NftImageProps = {
   nfts: Nft[];
@@ -10,7 +11,7 @@ const NftImage: FunctionComponent<NftImageProps> = ({ nfts }) => {
     <div className="flex gap-5 flex-wrap justify-center items-center">
       {nfts.map((nft, index) => (
         <div key={index} className="flex justify-center items-center flex-col">
-          <img className={styles.nftStyle} src={nft.imgSrc} />
+          <CDNImg className={styles.nftStyle} src={nft.imgSrc} />
           {nft.level && nfts.length > 1 ? (
             <p className={styles.level}>Level {nft.level}</p>
           ) : null}

--- a/components/quests/nftIssuer.tsx
+++ b/components/quests/nftIssuer.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from "react";
 import styles from "../../styles/quests.module.css";
+import { CDNImg } from "../cdn/image";
 
 type NftIssuerProps = {
   issuer: Issuer;
@@ -8,7 +9,7 @@ type NftIssuerProps = {
 const NftIssuer: FunctionComponent<NftIssuerProps> = ({ issuer }) => {
   return (
     <div className={styles.issuer}>
-      <img width={25} src={issuer.logoFavicon} />
+      <CDNImg width={25} src={issuer.logoFavicon} />
       <p>{issuer.name}</p>
     </div>
   );

--- a/components/quests/quest.tsx
+++ b/components/quests/quest.tsx
@@ -5,6 +5,7 @@ import CheckIcon from "../UI/iconsComponents/icons/checkIcon";
 import UnavailableIcon from "../UI/iconsComponents/icons/unavailableIcon";
 import Card from "../UI/card";
 import styles from "../../styles/quests.module.css";
+import { CDNImg } from "../cdn/image";
 
 type QuestProps = {
   onClick: () => void;
@@ -58,7 +59,7 @@ const Quest: FunctionComponent<QuestProps> = ({
           </>
         ) : (
           <>
-            <img width={20} src={issuer.logoFavicon} />
+            <CDNImg width={20} src={issuer.logoFavicon} />
             <p className="text-white ml-2">{reward}</p>
           </>
         )}

--- a/components/quests/questCategory.tsx
+++ b/components/quests/questCategory.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from "react";
 import styles from "../../styles/Home.module.css";
 import Link from "next/link";
+import { CDNImg } from "../cdn/image";
 
 type QuestCategoryProps = {
   category: QuestCategory;
@@ -18,7 +19,7 @@ const QuestCategory: FunctionComponent<QuestCategoryProps> = ({ category }) => {
           {category.questNumber} quest{category.questNumber > 1 ? "s" : null}
         </p>
       </div>
-      <img src={category.img} />
+      <CDNImg src={category.img} />
     </Link>
   );
 };

--- a/components/quests/reward.tsx
+++ b/components/quests/reward.tsx
@@ -12,6 +12,7 @@ import {
   NotificationType,
   TransactionType,
 } from "../../constants/notifications";
+import { CDNImg } from "../cdn/image";
 
 type RewardProps = {
   onClick: () => void;
@@ -59,7 +60,7 @@ const Reward: FunctionComponent<RewardProps> = ({
     <div className={styles.reward}>
       <div className="flex">
         <p className="mr-1">Reward: </p>
-        <img width={25} src={imgSrc} />
+        <CDNImg width={25} src={imgSrc} />
         <p className="ml-1">{reward}</p>
       </div>
       <div className="max-w-lg">

--- a/components/quiz/questionKinds/imageChoice.tsx
+++ b/components/quiz/questionKinds/imageChoice.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, useEffect } from "react";
 import styles from "../../../styles/components/quests/quiz.module.css";
+import { CDNImg } from "../../cdn/image";
 
 type ImageChoiceProps = {
   setSelected: (s: boolean) => void;
@@ -42,7 +43,7 @@ const ImageChoice: FunctionComponent<ImageChoiceProps> = ({
               checked={selectedOptions.includes(index)}
             />
             <label className={styles.checkboxLabel} htmlFor={option}>
-              <img src={option} className={styles.checkboxImage} />
+              <CDNImg src={option} className={styles.checkboxImage} />
             </label>
           </div>
         ))}

--- a/components/quiz/step.tsx
+++ b/components/quiz/step.tsx
@@ -5,6 +5,7 @@ import QuestionRouter from "./questionRouter";
 import styles from "../../styles/components/quests/quiz.module.css";
 import CheckMarkIcon from "../UI/iconsComponents/icons/checkMarkIcon";
 import NftIssuer from "../quests/nftIssuer";
+import { CDNImg } from "../cdn/image";
 
 type StepProps = {
   setStep: (s: number) => void;
@@ -68,7 +69,7 @@ const Step: FunctionComponent<StepProps> = ({
   const layoutElements =
     question && question.layout === "illustrated_left" ? (
       <div className={styles.leftIllustration}>
-        <img src={question.image_for_layout as string} alt="illustration" />
+        <CDNImg src={question.image_for_layout as string} alt="illustration" />
       </div>
     ) : null;
 


### PR DESCRIPTION
This pull request introduces two new components: `CDNImg` and `CDNImage`. These components function identically to the standard `img` from HTML and `Image` from Next.js, with one key enhancement. In production environments, they automatically prefix URLs with our CDN URL. This integration enables faster and cheaper serving of images through our CDN.