### PR TITLE
fix: update Argent Web wallet package

### DIFF
--- a/app/provider.tsx
+++ b/app/provider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useMemo } from "react";
-import { WebWalletConnector } from "@argent/starknet-react-webwallet-connector";
+import { WebWalletConnector } from "starknetkit/webwallet";
 import { goerli, mainnet } from "@starknet-react/chains";
 import {
   Connector,

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "prettier": "^2.8.8",
     "tailwindcss": "^3.1.8",
     "ts-jest": "^29.0.3",
-    "typescript": "^4.7.4"
+    "typescript": "^5.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "prettier": "prettier --write '**/*.{ts,tsx,css}'"
   },
   "dependencies": {
-    "@argent/starknet-react-webwallet-connector": "^6.5.0",
     "@emotion/react": "^11.10.0",
     "@emotion/styled": "^11.10.0",
     "@mui/icons-material": "^5.8.4",
@@ -43,6 +42,7 @@
     "react-use": "^17.4.0",
     "starknet": "^5.19.5",
     "starknetid.js": "^1.5.6",
+    "starknetkit": "^1.0.21",
     "three": "^0.155.0",
     "twitter-api-sdk": "^1.2.1"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
This PR uses the new `starknetkit` package from Argent to handle the web wallet. For it to works, it updates `typescript` to above v5 and update `tsconfig` `moduleResolution` to `bundler`