### PR TITLE
fix: build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react-dom": "^18.2.0",
     "react-icons": "^4.4.0",
     "react-intersection-observer": "^9.5.2",
-    "react-loader-spinner": "^5.2.0",
+    "react-loader-spinner": "5.4.5",
     "react-use": "^17.4.0",
     "starknet": "^5.19.5",
     "starknetid.js": "^1.5.6",


### PR DESCRIPTION
This PR fixes a build error that occurs because of the package `react-loader-spinner` that made a breaking change but did not follow semantic versioning of packages. 