### PR TITLE
feat: add boosted quests tag

### DIFF
--- a/components/quests/quest.tsx
+++ b/components/quests/quest.tsx
@@ -7,6 +7,8 @@ import styles from "@styles/quests.module.css";
 import { CDNImg } from "@components/cdn/image";
 import QuestCard from "./questCard";
 
+const BOOSTED_QUESTS = [23];
+
 type QuestProps = {
   onClick: () => void;
   imgSrc: string;
@@ -46,23 +48,39 @@ const Quest: FunctionComponent<QuestProps> = ({
       >
         <p className="text-gray-400">{issuer.name}</p>
       </div>
-      <div className={styles.issuer}>
-        {isCompleted ? (
-          <>
-            <p className="text-white mr-2">Done</p>
-            <CheckIcon width="24" color="#6AFFAF" />
-          </>
-        ) : expired ? (
-          <>
-            <p className="text-white mr-2">Expired</p>
-            <UnavailableIcon width="24" color="#D32F2F" />
-          </>
-        ) : (
-          <>
-            <CDNImg width={20} src={issuer.logoFavicon} />
-            <p className="text-white ml-2">{reward}</p>
-          </>
-        )}
+      <div className="flex gap-2">
+        <div className={styles.issuer}>
+          {isCompleted ? (
+            <>
+              <p className="text-white mr-2">Done</p>
+              <CheckIcon width="24" color="#6AFFAF" />
+            </>
+          ) : expired ? (
+            <>
+              <p className="text-white mr-2">Expired</p>
+              <UnavailableIcon width="24" color="#D32F2F" />
+            </>
+          ) : (
+            <>
+              <CDNImg width={20} src={issuer.logoFavicon} />
+              <p className="text-white ml-2">{reward}</p>
+            </>
+          )}
+        </div>
+        {BOOSTED_QUESTS.includes(id) ? (
+          <div
+            className={styles.issuer}
+            style={{ gap: 0, padding: "8px 16px" }}
+          >
+            <CDNImg
+              src={"/icons/usdc.svg"}
+              width={20}
+              height={20}
+              alt="usdc icon"
+            />
+            <p className="text-white ml-2">{1500}</p>
+          </div>
+        ) : null}
       </div>
     </QuestCard>
   );


### PR DESCRIPTION
This PR modifies the quest card.
I have added a temporary config to make this tag visible if it is included in this array.
`const BOOSTED_QUESTS = [23];`
This can help with modifying temporarily all quests which need this tag. This can be done by just adding their `id` to this array

current behaviour:
we don't show any boosted tag .This doesn't tell user that he can complete this quest to earn money. Might be interesting to add this and increase boost impressions.
<img width="345" alt="Screenshot 2023-12-30 at 4 08 13 PM" src="https://github.com/starknet-id/starknet.quest/assets/41674634/df52b5ea-2a3a-4621-8ffe-3a55152292fe">

new behaviour:
Added a boost tag for any boosted quests which come up.
<img width="323" alt="Screenshot 2023-12-30 at 4 09 20 PM" src="https://github.com/starknet-id/starknet.quest/assets/41674634/5d5ed085-93ff-47b4-b33c-81c6927ee43a">
