### PR TITLE
feat: add support for multiple winners

### DIFF
--- a/app/quest-boost/[boostId]/page.tsx
+++ b/app/quest-boost/[boostId]/page.tsx
@@ -77,7 +77,7 @@ export default function Page({ params }: BoostQuestPageProps) {
 
   const handleButtonClick = useCallback(() => {
     if (!boost) return;
-    if (hexToDecimal(boost?.winner ?? "") !== hexToDecimal(address))
+    if (boost?.winner?.includes(hexToDecimal(address)))
       updateBoostClaimStatus(boost?.id, true);
 
     router.push(`/quest-boost/claim/${boost?.id}`);

--- a/app/quest-boost/claim/[boostId]/page.tsx
+++ b/app/quest-boost/claim/[boostId]/page.tsx
@@ -134,7 +134,13 @@ export default function Page({ params }: BoostQuestPageProps) {
                     )}
                   </div>
                   <div className={styles.claim_button_text}>
-                    <p className={styles.claim_amount}>{boost?.amount}</p>
+                    <p className={styles.claim_amount}>
+                      {boost
+                        ? parseInt(
+                            String(boost?.amount / boost?.num_of_winners)
+                          )
+                        : 0}
+                    </p>
                   </div>
                   <div className={styles.token_symbol_container}>
                     <div className="bg-[#1F1F25] flex-1 rounded-[12px] flex justify-center items-center">

--- a/app/quest-boost/claim/[boostId]/page.tsx
+++ b/app/quest-boost/claim/[boostId]/page.tsx
@@ -61,9 +61,7 @@ export default function Page({ params }: BoostQuestPageProps) {
 
   const isUserWinner = useMemo(() => {
     return (
-      boost &&
-      boost?.winner &&
-      hexToDecimal(boost?.winner) === hexToDecimal(address)
+      boost && boost?.winner && boost?.winner?.includes(hexToDecimal(address))
     );
   }, [boost, address]);
 
@@ -171,7 +169,7 @@ export default function Page({ params }: BoostQuestPageProps) {
                 <Button
                   disabled={
                     boost?.claimed ||
-                    hexToDecimal(boost?.winner ?? "") !== hexToDecimal(address)
+                    boost?.winner?.includes(hexToDecimal(address))
                   }
                   onClick={handleClaimClick}
                 >

--- a/app/quest-boost/claim/[boostId]/page.tsx
+++ b/app/quest-boost/claim/[boostId]/page.tsx
@@ -33,6 +33,7 @@ export default function Page({ params }: BoostQuestPageProps) {
   const [transactionHash, setTransactionHash] = useState<string>("");
   const [winnerList, setWinnerList] = useState<string[]>([]);
   const { updateBoostClaimStatus } = useBoost();
+  const [displayAmount, setDisplayAmount] = useState<number>(0);
 
   const fetchPageData = async () => {
     try {
@@ -74,6 +75,7 @@ export default function Page({ params }: BoostQuestPageProps) {
     // convert values in winner array from hex to decimal
     if (!boost.winner) return false;
 
+    setDisplayAmount(parseInt(String(boost?.amount / boost?.num_of_winners)));
     return winnerList.includes(hexToDecimal(address));
   }, [boost, address, winnerList]);
 
@@ -147,11 +149,7 @@ export default function Page({ params }: BoostQuestPageProps) {
                   </div>
                   <div className={styles.claim_button_text}>
                     <p className={styles.claim_amount}>
-                      {boost
-                        ? parseInt(
-                            String(boost?.amount / boost?.num_of_winners)
-                          )
-                        : 0}
+                      {boost ? displayAmount : 0}
                     </p>
                   </div>
                   <div className={styles.token_symbol_container}>

--- a/types/frontTypes.d.ts
+++ b/types/frontTypes.d.ts
@@ -66,10 +66,11 @@ type Boost = {
   expiry: number;
   quests: number[];
   claimed: boolean;
-  winner: string | null;
+  winner: string[] | null;
   img_url: string;
   id: number;
   name: string;
+  num_of_winners: number;
 };
 
 type Reward = {

--- a/utils/callData.ts
+++ b/utils/callData.ts
@@ -1,7 +1,9 @@
 import { CallData, uint256 } from "starknet";
 
 export function boostClaimCall(boost: Boost, sign: Signature) {
-  const amount = uint256.bnToUint256(boost.amount / boost.num_of_winners);
+  const amount = uint256.bnToUint256(
+    parseInt(String(boost.amount / boost.num_of_winners))
+  );
   const claimCallData = CallData.compile({
     amount: amount,
     token: boost.token,

--- a/utils/callData.ts
+++ b/utils/callData.ts
@@ -1,7 +1,7 @@
 import { CallData, uint256 } from "starknet";
 
 export function boostClaimCall(boost: Boost, sign: Signature) {
-  const amount = uint256.bnToUint256(boost.amount);
+  const amount = uint256.bnToUint256(boost.amount / boost.num_of_winners);
   const claimCallData = CallData.compile({
     amount: amount,
     token: boost.token,


### PR DESCRIPTION
The winners will now be an array. We check if the user's address is in the array and if yes then the user can continue the winner flow otherwise he will see the looser flow. The final amount also changes for the contract call data and the claim page display amount.

This also means that the types of the Boost Document will change