### PR TITLE
fix: winner claim bug

### DIFF
--- a/app/quest-boost/[boostId]/page.tsx
+++ b/app/quest-boost/[boostId]/page.tsx
@@ -19,6 +19,7 @@ import BackButton from "@components/UI/backButton";
 import useBoost from "@hooks/useBoost";
 import { getTokenName } from "@utils/tokenService";
 import BoostSkeleton from "@components/skeletons/boostSkeleton";
+import { TOKEN_DECIMAL_MAP } from "@utils/constants";
 
 type BoostQuestPageProps = {
   params: {
@@ -142,7 +143,13 @@ export default function Page({ params }: BoostQuestPageProps) {
               <p>Reward:</p>
               <div className="flex flex-row gap-2">
                 <p className={styles.claim_button_text_highlight}>
-                  {boost?.amount} {getTokenName(boost?.token ?? "")}
+                  {parseInt(
+                    String(
+                      boost?.amount /
+                        TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
+                    )
+                  )}{" "}
+                  {getTokenName(boost?.token ?? "")}
                 </p>
                 <TokenSymbol tokenAddress={boost?.token ?? ""} />
               </div>

--- a/app/quest-boost/[boostId]/page.tsx
+++ b/app/quest-boost/[boostId]/page.tsx
@@ -145,7 +145,7 @@ export default function Page({ params }: BoostQuestPageProps) {
                 <p className={styles.claim_button_text_highlight}>
                   {parseInt(
                     String(
-                      boost?.amount /
+                      boost.amount /
                         TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
                     )
                   )}{" "}

--- a/app/quest-boost/[boostId]/page.tsx
+++ b/app/quest-boost/[boostId]/page.tsx
@@ -93,7 +93,6 @@ export default function Page({ params }: BoostQuestPageProps) {
   const handleButtonClick = useCallback(() => {
     if (!boost || !address) return;
     if (!winnerList.includes(hexToDecimal(address))) {
-      console.log({ winnerList, address: hexToDecimal(address) });
       updateBoostClaimStatus(address, boost?.id, true);
     }
 

--- a/app/quest-boost/[boostId]/page.tsx
+++ b/app/quest-boost/[boostId]/page.tsx
@@ -147,7 +147,12 @@ export default function Page({ params }: BoostQuestPageProps) {
                     ? parseInt(
                         String(
                           boost?.amount /
-                            TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
+                            Math.pow(
+                              10,
+                              TOKEN_DECIMAL_MAP[
+                                getTokenName(boost?.token ?? "")
+                              ]
+                            )
                         )
                       )
                     : 0}{" "}

--- a/app/quest-boost/[boostId]/page.tsx
+++ b/app/quest-boost/[boostId]/page.tsx
@@ -143,12 +143,14 @@ export default function Page({ params }: BoostQuestPageProps) {
               <p>Reward:</p>
               <div className="flex flex-row gap-2">
                 <p className={styles.claim_button_text_highlight}>
-                  {parseInt(
-                    String(
-                      boost.amount /
-                        TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
-                    )
-                  )}{" "}
+                  {boost
+                    ? parseInt(
+                        String(
+                          boost?.amount /
+                            TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
+                        )
+                      )
+                    : 0}{" "}
                   {getTokenName(boost?.token ?? "")}
                 </p>
                 <TokenSymbol tokenAddress={boost?.token ?? ""} />

--- a/app/quest-boost/[boostId]/page.tsx
+++ b/app/quest-boost/[boostId]/page.tsx
@@ -92,8 +92,10 @@ export default function Page({ params }: BoostQuestPageProps) {
 
   const handleButtonClick = useCallback(() => {
     if (!boost || !address) return;
-    if (!winnerList.includes(hexToDecimal(address)))
+    if (!winnerList.includes(hexToDecimal(address))) {
+      console.log({ winnerList, address: hexToDecimal(address) });
       updateBoostClaimStatus(address, boost?.id, true);
+    }
 
     router.push(`/quest-boost/claim/${boost?.id}`);
   }, [boost, address]);

--- a/app/quest-boost/[boostId]/page.tsx
+++ b/app/quest-boost/[boostId]/page.tsx
@@ -98,7 +98,7 @@ export default function Page({ params }: BoostQuestPageProps) {
     }
 
     router.push(`/quest-boost/claim/${boost?.id}`);
-  }, [boost, address]);
+  }, [boost, address, winnerList]);
 
   useEffect(() => {
     fetchPageData();

--- a/app/quest-boost/claim/[boostId]/page.tsx
+++ b/app/quest-boost/claim/[boostId]/page.tsx
@@ -112,7 +112,9 @@ export default function Page({ params }: BoostQuestPageProps) {
       const { transaction_hash } = await account.execute(
         boostClaimCall(boost, sign)
       );
-      updateBoostClaimStatus(address, boost?.id, true);
+      if (transaction_hash) {
+        updateBoostClaimStatus(address, boost?.id, true);
+      }
       setTransactionHash(transaction_hash);
     };
 

--- a/app/quest-boost/claim/[boostId]/page.tsx
+++ b/app/quest-boost/claim/[boostId]/page.tsx
@@ -77,12 +77,8 @@ export default function Page({ params }: BoostQuestPageProps) {
     if (!boost.winner) return false;
 
     setDisplayAmount(
-      parseInt(
-        String(
-          boost?.amount /
-            Math.pow(10, TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")])
-        )
-      )
+      parseInt(String(boost?.amount / boost?.num_of_winners)) /
+        Math.pow(10, TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")])
     );
     return winnerList.includes(hexToDecimal(address));
   }, [boost, address, winnerList]);

--- a/app/quest-boost/claim/[boostId]/page.tsx
+++ b/app/quest-boost/claim/[boostId]/page.tsx
@@ -79,7 +79,8 @@ export default function Page({ params }: BoostQuestPageProps) {
     setDisplayAmount(
       parseInt(
         String(
-          boost?.amount / TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
+          boost?.amount /
+            Math.pow(10, TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")])
         )
       )
     );

--- a/app/quest-boost/claim/[boostId]/page.tsx
+++ b/app/quest-boost/claim/[boostId]/page.tsx
@@ -15,6 +15,7 @@ import { hexToDecimal } from "@utils/feltService";
 import { boostClaimCall } from "@utils/callData";
 import { getTokenName } from "@utils/tokenService";
 import useBoost from "@hooks/useBoost";
+import { TOKEN_DECIMAL_MAP } from "@utils/constants";
 
 type BoostQuestPageProps = {
   params: {
@@ -75,7 +76,13 @@ export default function Page({ params }: BoostQuestPageProps) {
     // convert values in winner array from hex to decimal
     if (!boost.winner) return false;
 
-    setDisplayAmount(parseInt(String(boost?.amount / boost?.num_of_winners)));
+    setDisplayAmount(
+      parseInt(
+        String(
+          boost?.amount / TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
+        )
+      )
+    );
     return winnerList.includes(hexToDecimal(address));
   }, [boost, address, winnerList]);
 

--- a/app/quest-boost/claim/[boostId]/page.tsx
+++ b/app/quest-boost/claim/[boostId]/page.tsx
@@ -109,7 +109,6 @@ export default function Page({ params }: BoostQuestPageProps) {
         boostClaimCall(boost, sign)
       );
       if (transaction_hash) {
-        console.log("Transaction hash", transaction_hash);
         updateBoostClaimStatus(address, boost?.id, true);
       }
       setTransactionHash(transaction_hash);

--- a/app/quest-boost/claim/[boostId]/page.tsx
+++ b/app/quest-boost/claim/[boostId]/page.tsx
@@ -109,6 +109,7 @@ export default function Page({ params }: BoostQuestPageProps) {
         boostClaimCall(boost, sign)
       );
       if (transaction_hash) {
+        console.log("Transaction hash", transaction_hash);
         updateBoostClaimStatus(address, boost?.id, true);
       }
       setTransactionHash(transaction_hash);

--- a/components/UI/navbar.tsx
+++ b/components/UI/navbar.tsx
@@ -66,7 +66,6 @@ const Navbar: FunctionComponent = () => {
       linkText: "",
     },
   ]);
-  const [displayAmount, setDisplayAmount] = useState<string>("0");
 
   const fetchAndUpdateNotifications = async () => {
     if (!address) return;

--- a/components/UI/navbar.tsx
+++ b/components/UI/navbar.tsx
@@ -78,7 +78,8 @@ const Navbar: FunctionComponent = () => {
         title: "Congratulations! 🎉",
         subtext: `You have just won ${parseInt(
           String(
-            boost?.amount / TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
+            boost?.amount /
+              Math.pow(10, TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")])
           )
         )} USDC thanks to the "${boost.name}” boost`,
         link: "/quest-boost/" + boost.id,

--- a/components/UI/navbar.tsx
+++ b/components/UI/navbar.tsx
@@ -33,6 +33,7 @@ import { getPendingBoostClaims } from "@services/apiService";
 import { hexToDecimal } from "@utils/feltService";
 import CloseFilledIcon from "./iconsComponents/icons/closeFilledIcon";
 import { getCurrentNetwork } from "@utils/network";
+import { TOKEN_DECIMAL_MAP } from "@utils/constants";
 
 const Navbar: FunctionComponent = () => {
   const currentNetwork = getCurrentNetwork();
@@ -73,7 +74,11 @@ const Navbar: FunctionComponent = () => {
     res.forEach((boost: Boost) => {
       const data = {
         title: "Congratulations! 🎉",
-        subtext: `You have just won ${boost.amount} USDC thanks to the "${boost.name}” boost`,
+        subtext: `You have just won ${parseInt(
+          String(
+            boost?.amount / TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
+          )
+        )} USDC thanks to the "${boost.name}” boost`,
         link: "/quest-boost/" + boost.id,
         linkText: "Claim your reward",
       };

--- a/components/UI/navbar.tsx
+++ b/components/UI/navbar.tsx
@@ -34,6 +34,7 @@ import { hexToDecimal } from "@utils/feltService";
 import CloseFilledIcon from "./iconsComponents/icons/closeFilledIcon";
 import { getCurrentNetwork } from "@utils/network";
 import { TOKEN_DECIMAL_MAP } from "@utils/constants";
+import { getTokenName } from "@utils/tokenService";
 
 const Navbar: FunctionComponent = () => {
   const currentNetwork = getCurrentNetwork();
@@ -65,6 +66,7 @@ const Navbar: FunctionComponent = () => {
       linkText: "",
     },
   ]);
+  const [displayAmount, setDisplayAmount] = useState<string>("0");
 
   const fetchAndUpdateNotifications = async () => {
     if (!address) return;

--- a/components/UI/navbar.tsx
+++ b/components/UI/navbar.tsx
@@ -75,12 +75,10 @@ const Navbar: FunctionComponent = () => {
     res.forEach((boost: Boost) => {
       const data = {
         title: "Congratulations! 🎉",
-        subtext: `You have just won ${parseInt(
-          String(
-            boost?.amount /
-              Math.pow(10, TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")])
-          )
-        )} USDC thanks to the "${boost.name}” boost`,
+        subtext: `You have just won ${
+          parseInt(String(boost?.amount / boost?.num_of_winners)) /
+          Math.pow(10, TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")])
+        } USDC thanks to the "${boost.name}” boost`,
         link: "/quest-boost/" + boost.id,
         linkText: "Claim your reward",
       };

--- a/components/quest-boost/boostCard.tsx
+++ b/components/quest-boost/boostCard.tsx
@@ -10,6 +10,7 @@ import useBoost from "@hooks/useBoost";
 import theme from "@styles/theme";
 import { useAccount } from "@starknet-react/core";
 import { TOKEN_DECIMAL_MAP } from "@utils/constants";
+import { getTokenName } from "@utils/tokenService";
 
 type BoostCardProps = {
   boost: Boost;

--- a/components/quest-boost/boostCard.tsx
+++ b/components/quest-boost/boostCard.tsx
@@ -9,6 +9,7 @@ import TokenSymbol from "./TokenSymbol";
 import useBoost from "@hooks/useBoost";
 import theme from "@styles/theme";
 import { useAccount } from "@starknet-react/core";
+import { TOKEN_DECIMAL_MAP } from "@utils/constants";
 
 type BoostCardProps = {
   boost: Boost;
@@ -86,7 +87,14 @@ const BoostCard: FunctionComponent<BoostCardProps> = ({
           </p>
           {!hasUserCompletedBoost && boost.expiry > Date.now() ? (
             <div className="flex flex-row gap-2 items-center p-1.5">
-              <p>{boost?.amount}</p>
+              <p>
+                {parseInt(
+                  String(
+                    boost?.amount /
+                      TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
+                  )
+                )}
+              </p>
               <TokenSymbol tokenAddress={boost.token} />
             </div>
           ) : (

--- a/components/quest-boost/boostCard.tsx
+++ b/components/quest-boost/boostCard.tsx
@@ -92,7 +92,10 @@ const BoostCard: FunctionComponent<BoostCardProps> = ({
                 {parseInt(
                   String(
                     boost?.amount /
-                      TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
+                      Math.pow(
+                        10,
+                        TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
+                      )
                   )
                 )}
               </p>

--- a/components/quests/quest.tsx
+++ b/components/quests/quest.tsx
@@ -15,6 +15,7 @@ import QuestCard from "./questCard";
 import { getBoosts } from "@services/apiService";
 import TokenSymbol from "@components/quest-boost/TokenSymbol";
 import { TOKEN_DECIMAL_MAP } from "@utils/constants";
+import { getTokenName } from "@utils/tokenService";
 
 type QuestProps = {
   onClick: () => void;

--- a/components/quests/quest.tsx
+++ b/components/quests/quest.tsx
@@ -14,6 +14,7 @@ import { CDNImg } from "@components/cdn/image";
 import QuestCard from "./questCard";
 import { getBoosts } from "@services/apiService";
 import TokenSymbol from "@components/quest-boost/TokenSymbol";
+import { TOKEN_DECIMAL_MAP } from "@utils/constants";
 
 type QuestProps = {
   onClick: () => void;
@@ -110,7 +111,14 @@ const Quest: FunctionComponent<QuestProps> = ({
             style={{ gap: 0, padding: "8px 16px" }}
           >
             <TokenSymbol tokenAddress={boost?.token} />
-            <p className="text-white ml-2">{boost?.amount}</p>
+            <p className="text-white ml-2">
+              {parseInt(
+                String(
+                  boost?.amount /
+                    TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
+                )
+              )}
+            </p>
           </div>
         ) : null}
       </div>

--- a/components/quests/quest.tsx
+++ b/components/quests/quest.tsx
@@ -116,7 +116,10 @@ const Quest: FunctionComponent<QuestProps> = ({
               {parseInt(
                 String(
                   boost?.amount /
-                    TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
+                    Math.pow(
+                      10,
+                      TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
+                    )
                 )
               )}
             </p>

--- a/utils/callData.ts
+++ b/utils/callData.ts
@@ -2,7 +2,7 @@ import { CallData, uint256 } from "starknet";
 
 export function boostClaimCall(boost: Boost, sign: Signature) {
   const amount = uint256.bnToUint256(
-    parseInt(String(boost.amount / boost.num_of_winners)) * Math.pow(10, 6)
+    parseInt(String(boost.amount / boost.num_of_winners))
   );
   console.log("amount", amount);
   const claimCallData = CallData.compile({

--- a/utils/callData.ts
+++ b/utils/callData.ts
@@ -2,8 +2,9 @@ import { CallData, uint256 } from "starknet";
 
 export function boostClaimCall(boost: Boost, sign: Signature) {
   const amount = uint256.bnToUint256(
-    parseInt(String(boost.amount / boost.num_of_winners)) * Math.pow(10, 6)
+    parseInt(String(boost.amount / boost.num_of_winners))
   );
+  console.log("amount", amount);
   const claimCallData = CallData.compile({
     amount: amount,
     token: boost.token,

--- a/utils/callData.ts
+++ b/utils/callData.ts
@@ -2,7 +2,7 @@ import { CallData, uint256 } from "starknet";
 
 export function boostClaimCall(boost: Boost, sign: Signature) {
   const amount = uint256.bnToUint256(
-    parseInt(String(boost.amount / boost.num_of_winners)) * Math.pow(10, 2)
+    parseInt(String(boost.amount / boost.num_of_winners) * Math.pow(10, 6))
   );
   console.log("amount", amount);
   const claimCallData = CallData.compile({

--- a/utils/callData.ts
+++ b/utils/callData.ts
@@ -2,9 +2,7 @@ import { CallData, uint256 } from "starknet";
 
 export function boostClaimCall(boost: Boost, sign: Signature) {
   const amount = uint256.bnToUint256(
-    parseInt(
-      parseInt(String(boost.amount / boost.num_of_winners)) * Math.pow(10, 6)
-    )
+    parseInt(String(boost.amount / boost.num_of_winners)) * Math.pow(10, 6)
   );
   console.log("amount", amount);
   const claimCallData = CallData.compile({

--- a/utils/callData.ts
+++ b/utils/callData.ts
@@ -3,7 +3,7 @@ import { CallData, uint256 } from "starknet";
 export function boostClaimCall(boost: Boost, sign: Signature) {
   const amount = uint256.bnToUint256(
     parseInt(
-      parseInt(String(boost.amount / boost.num_of_winners) * Math.pow(10, 6))
+      parseInt(String(boost.amount / boost.num_of_winners)) * Math.pow(10, 6)
     )
   );
   console.log("amount", amount);

--- a/utils/callData.ts
+++ b/utils/callData.ts
@@ -2,7 +2,9 @@ import { CallData, uint256 } from "starknet";
 
 export function boostClaimCall(boost: Boost, sign: Signature) {
   const amount = uint256.bnToUint256(
-    parseInt(String(boost.amount / boost.num_of_winners) * Math.pow(10, 6))
+    parseInt(
+      parseInt(String(boost.amount / boost.num_of_winners) * Math.pow(10, 6))
+    )
   );
   console.log("amount", amount);
   const claimCallData = CallData.compile({

--- a/utils/callData.ts
+++ b/utils/callData.ts
@@ -2,7 +2,7 @@ import { CallData, uint256 } from "starknet";
 
 export function boostClaimCall(boost: Boost, sign: Signature) {
   const amount = uint256.bnToUint256(
-    parseInt(String(boost.amount / boost.num_of_winners))
+    parseInt(String(boost.amount / boost.num_of_winners)) * Math.pow(10, 6)
   );
   const claimCallData = CallData.compile({
     amount: amount,

--- a/utils/callData.ts
+++ b/utils/callData.ts
@@ -4,7 +4,6 @@ export function boostClaimCall(boost: Boost, sign: Signature) {
   const amount = uint256.bnToUint256(
     parseInt(String(boost.amount / boost.num_of_winners))
   );
-  console.log("amount", amount);
   const claimCallData = CallData.compile({
     amount: amount,
     token: boost.token,

--- a/utils/callData.ts
+++ b/utils/callData.ts
@@ -2,7 +2,7 @@ import { CallData, uint256 } from "starknet";
 
 export function boostClaimCall(boost: Boost, sign: Signature) {
   const amount = uint256.bnToUint256(
-    parseInt(String(boost.amount / boost.num_of_winners))
+    parseInt(String(boost.amount / boost.num_of_winners)) * Math.pow(10, 2)
   );
   console.log("amount", amount);
   const claimCallData = CallData.compile({

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -35,3 +35,8 @@ export const TOKEN_ADDRESS_MAP = {
     ETH: "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
   },
 };
+
+export const TOKEN_DECIMAL_MAP = {
+  USDC: 6,
+  ETH: 18,
+};


### PR DESCRIPTION
closes #481 
We have now added token decimals to the boost document so that the users get the accurate amount. Previously the amount would have been very small since the boost amount was not multiplied by it's respective decimals