### PR TITLE
feat: add decimals support

### DIFF
--- a/app/quest-boost/[boostId]/page.tsx
+++ b/app/quest-boost/[boostId]/page.tsx
@@ -143,8 +143,7 @@ export default function Page({ params }: BoostQuestPageProps) {
               <p>Reward:</p>
               <div className="flex flex-row gap-2">
                 <p className={styles.claim_button_text_highlight}>
-                  {boost?.amount}
-                  {getTokenName(boost?.token ?? "")}
+                  {boost?.amount} {getTokenName(boost?.token ?? "")}
                 </p>
                 <TokenSymbol tokenAddress={boost?.token ?? ""} />
               </div>

--- a/app/quest-boost/[boostId]/page.tsx
+++ b/app/quest-boost/[boostId]/page.tsx
@@ -143,14 +143,7 @@ export default function Page({ params }: BoostQuestPageProps) {
               <p>Reward:</p>
               <div className="flex flex-row gap-2">
                 <p className={styles.claim_button_text_highlight}>
-                  {boost
-                    ? parseInt(
-                        String(
-                          boost?.amount /
-                            Math.pow(10, boost?.token_decimals ?? 0)
-                        )
-                      )
-                    : 0}{" "}
+                  {boost?.amount}
                   {getTokenName(boost?.token ?? "")}
                 </p>
                 <TokenSymbol tokenAddress={boost?.token ?? ""} />

--- a/app/quest-boost/[boostId]/page.tsx
+++ b/app/quest-boost/[boostId]/page.tsx
@@ -147,12 +147,7 @@ export default function Page({ params }: BoostQuestPageProps) {
                     ? parseInt(
                         String(
                           boost?.amount /
-                            Math.pow(
-                              10,
-                              TOKEN_DECIMAL_MAP[
-                                getTokenName(boost?.token ?? "")
-                              ]
-                            )
+                            Math.pow(10, boost?.token_decimals ?? 0)
                         )
                       )
                     : 0}{" "}

--- a/app/quest-boost/claim/[boostId]/page.tsx
+++ b/app/quest-boost/claim/[boostId]/page.tsx
@@ -76,10 +76,7 @@ export default function Page({ params }: BoostQuestPageProps) {
     // convert values in winner array from hex to decimal
     if (!boost.winner) return false;
 
-    setDisplayAmount(
-      parseInt(String(boost?.amount / boost?.num_of_winners)) /
-        Math.pow(10, boost?.token_decimals ?? 0)
-    );
+    setDisplayAmount(parseInt(String(boost?.amount / boost?.num_of_winners)));
     return winnerList.includes(hexToDecimal(address));
   }, [boost, address, winnerList]);
 

--- a/app/quest-boost/claim/[boostId]/page.tsx
+++ b/app/quest-boost/claim/[boostId]/page.tsx
@@ -78,7 +78,7 @@ export default function Page({ params }: BoostQuestPageProps) {
 
     setDisplayAmount(
       parseInt(String(boost?.amount / boost?.num_of_winners)) /
-        Math.pow(10, TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")])
+        Math.pow(10, boost?.token_decimals ?? 0)
     );
     return winnerList.includes(hexToDecimal(address));
   }, [boost, address, winnerList]);

--- a/components/UI/navbar.tsx
+++ b/components/UI/navbar.tsx
@@ -75,10 +75,9 @@ const Navbar: FunctionComponent = () => {
     res.forEach((boost: Boost) => {
       const data = {
         title: "Congratulations! 🎉",
-        subtext: `You have just won ${
-          parseInt(String(boost?.amount / boost?.num_of_winners)) /
-          Math.pow(10, boost?.token_decimals ?? 0)
-        } USDC thanks to the "${boost.name}” boost`,
+        subtext: `You have just won ${parseInt(
+          String(boost?.amount / boost?.num_of_winners)
+        )} USDC thanks to the "${boost.name}” boost`,
         link: "/quest-boost/" + boost.id,
         linkText: "Claim your reward",
       };

--- a/components/UI/navbar.tsx
+++ b/components/UI/navbar.tsx
@@ -77,7 +77,7 @@ const Navbar: FunctionComponent = () => {
         title: "Congratulations! 🎉",
         subtext: `You have just won ${
           parseInt(String(boost?.amount / boost?.num_of_winners)) /
-          Math.pow(10, TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")])
+          Math.pow(10, boost?.token_decimals ?? 0)
         } USDC thanks to the "${boost.name}” boost`,
         link: "/quest-boost/" + boost.id,
         linkText: "Claim your reward",

--- a/components/quest-boost/boostCard.tsx
+++ b/components/quest-boost/boostCard.tsx
@@ -90,13 +90,7 @@ const BoostCard: FunctionComponent<BoostCardProps> = ({
             <div className="flex flex-row gap-2 items-center p-1.5">
               <p>
                 {parseInt(
-                  String(
-                    boost?.amount /
-                      Math.pow(
-                        10,
-                        TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
-                      )
-                  )
+                  String(boost?.amount / Math.pow(10, boost?.token_decimals ?? 0))
                 )}
               </p>
               <TokenSymbol tokenAddress={boost.token} />

--- a/components/quest-boost/boostCard.tsx
+++ b/components/quest-boost/boostCard.tsx
@@ -88,11 +88,7 @@ const BoostCard: FunctionComponent<BoostCardProps> = ({
           </p>
           {!hasUserCompletedBoost && boost.expiry > Date.now() ? (
             <div className="flex flex-row gap-2 items-center p-1.5">
-              <p>
-                {parseInt(
-                  String(boost?.amount / Math.pow(10, boost?.token_decimals ?? 0))
-                )}
-              </p>
+              <p>{boost?.amount}</p>
               <TokenSymbol tokenAddress={boost.token} />
             </div>
           ) : (

--- a/components/quests/quest.tsx
+++ b/components/quests/quest.tsx
@@ -112,11 +112,7 @@ const Quest: FunctionComponent<QuestProps> = ({
             style={{ gap: 0, padding: "8px 16px" }}
           >
             <TokenSymbol tokenAddress={boost?.token} />
-            <p className="text-white ml-2">
-              {parseInt(
-                String(boost?.amount / Math.pow(10, boost?.token_decimals ?? 0))
-              )}
-            </p>
+            <p className="text-white ml-2">{boost?.amount}</p>
           </div>
         ) : null}
       </div>

--- a/components/quests/quest.tsx
+++ b/components/quests/quest.tsx
@@ -114,13 +114,7 @@ const Quest: FunctionComponent<QuestProps> = ({
             <TokenSymbol tokenAddress={boost?.token} />
             <p className="text-white ml-2">
               {parseInt(
-                String(
-                  boost?.amount /
-                    Math.pow(
-                      10,
-                      TOKEN_DECIMAL_MAP[getTokenName(boost?.token ?? "")]
-                    )
-                )
+                String(boost?.amount / Math.pow(10, boost?.token_decimals ?? 0))
               )}
             </p>
           </div>

--- a/types/frontTypes.d.ts
+++ b/types/frontTypes.d.ts
@@ -71,6 +71,7 @@ type Boost = {
   id: number;
   name: string;
   num_of_winners: number;
+  token_decimals: number;
 };
 
 type Reward = {

--- a/utils/callData.ts
+++ b/utils/callData.ts
@@ -1,10 +1,9 @@
 import { CallData, uint256 } from "starknet";
 
 export function boostClaimCall(boost: Boost, sign: Signature) {
-  const amount = uint256.bnToUint256(
-    parseInt(String(boost.amount / boost.num_of_winners)) *
-      Math.pow(10, boost.token_decimals)
-  );
+  const finalAmount =
+    (boost.amount / boost.num_of_winners) * Math.pow(10, boost.token_decimals);
+  const amount = uint256.bnToUint256(finalAmount);
   const claimCallData = CallData.compile({
     amount: amount,
     token: boost.token,

--- a/utils/callData.ts
+++ b/utils/callData.ts
@@ -2,7 +2,8 @@ import { CallData, uint256 } from "starknet";
 
 export function boostClaimCall(boost: Boost, sign: Signature) {
   const amount = uint256.bnToUint256(
-    parseInt(String(boost.amount / boost.num_of_winners))
+    parseInt(String(boost.amount / boost.num_of_winners)) *
+      Math.pow(10, boost.token_decimals)
   );
   const claimCallData = CallData.compile({
     amount: amount,


### PR DESCRIPTION
add decimals support in the contract call data to support amount with 18 decimals.,

need to be tested after api is deployed

closes #481 
closes #491 