### PR TITLE
fix: claim button

### DIFF
--- a/app/quest-boost/[boostId]/page.tsx
+++ b/app/quest-boost/[boostId]/page.tsx
@@ -84,6 +84,8 @@ export default function Page({ params }: BoostQuestPageProps) {
     const chestOpened = getBoostClaimStatus(address, boost?.id);
     if (!isBoostExpired) {
       return "Boost in progress ⌛";
+    } else if (isBoostExpired && boost.winner === null) {
+      return "Raffle in Progress 🎩";
     } else if (!chestOpened) {
       return "See my reward 🎉";
     } else {
@@ -158,7 +160,9 @@ export default function Page({ params }: BoostQuestPageProps) {
                 <Button
                   disabled={
                     boost &&
-                    (!isBoostExpired || getBoostClaimStatus(address, boost.id))
+                    (!isBoostExpired ||
+                      getBoostClaimStatus(address, boost.id) ||
+                      (isBoostExpired && boost.winner === null))
                   }
                   onClick={handleButtonClick}
                 >

--- a/app/quest-boost/[boostId]/page.tsx
+++ b/app/quest-boost/[boostId]/page.tsx
@@ -101,6 +101,21 @@ export default function Page({ params }: BoostQuestPageProps) {
     router.push(`/quest-boost/claim/${boost?.id}`);
   }, [boost, address, winnerList]);
 
+  const buttonDisabled = useMemo(() => {
+    if (!address) return true;
+
+    // check if boost is not expired
+    // check if user has already claimed the boost
+    // check if boost expired but no winners assigned
+
+    return (
+      boost &&
+      (!isBoostExpired ||
+        getBoostClaimStatus(address, boost.id) ||
+        (isBoostExpired && boost.winner === null))
+    );
+  }, [boost, address, isBoostExpired]);
+
   useEffect(() => {
     fetchPageData();
   }, []);
@@ -157,15 +172,7 @@ export default function Page({ params }: BoostQuestPageProps) {
             </div>
             {address ? (
               <div>
-                <Button
-                  disabled={
-                    boost &&
-                    (!isBoostExpired ||
-                      getBoostClaimStatus(address, boost.id) ||
-                      (isBoostExpired && boost.winner === null))
-                  }
-                  onClick={handleButtonClick}
-                >
+                <Button disabled={buttonDisabled} onClick={handleButtonClick}>
                   {getButtonText()}
                 </Button>
               </div>

--- a/app/quest-boost/claim/[boostId]/page.tsx
+++ b/app/quest-boost/claim/[boostId]/page.tsx
@@ -206,12 +206,7 @@ export default function Page({ params }: BoostQuestPageProps) {
 
             <div className={styles.claim_button_animation}>
               {isUserWinner ? (
-                <Button
-                  disabled={(boost?.claimed && isUserWinner) || !isUserWinner}
-                  onClick={handleClaimClick}
-                >
-                  Collect my reward
-                </Button>
+                <Button onClick={handleClaimClick}>Collect my reward</Button>
               ) : (
                 <div className="block ml-auto mr-auto">
                   <Button onClick={() => router.push("/quest-boost")}>

--- a/components/quest-boost/boostCard.tsx
+++ b/components/quest-boost/boostCard.tsx
@@ -105,6 +105,11 @@ const BoostCard: FunctionComponent<BoostCardProps> = ({
                         <CheckIcon width="24" color="#6AFFAF" />
                       </>
                     ) : null
+                  ) : boost.winner === null ? (
+                    <>
+                      <p className="text-white">Done</p>
+                      <CheckIcon width="24" color="#6AFFAF" />
+                    </>
                   ) : isClickable ? (
                     <>
                       <p className="text-white">See my reward</p>


### PR DESCRIPTION
Currently users see a disabled claim button when they come on claim page. This happens because API returns `claimed` field to the FE but since this is not relevant to our usecase now so removing this check. Once removed we can see the button enabled button again.

To check if the user has claimed the reward we do two things now -
- check if there are any pending claims on the contract through the indexer with the help of endpoint - `/boost/get_pending_claims?addr=${addr}` - we do this on claim page [here](https://github.com/starknet-id/starknet.quest/pull/506/files#diff-be11aefe5538d0d3344fc0164ab52cfc8bf0bb431982afa2cc62aaa9e9020595R51)
- check on local storage if the user has clicked on the claim button - we do this on the boost listing page  [here](https://github.com/starknet-id/starknet.quest/pull/506/files#diff-d6e0706f1a72549f008504ce14c0d91fdd4839660dd7666f54016fdc3f803b81R114)