### PR TITLE
Remove hover action on expired quests #523

### DIFF
--- a/components/quiz/questionKinds/imageChoice.tsx
+++ b/components/quiz/questionKinds/imageChoice.tsx
@@ -26,8 +26,10 @@ const ImageChoice: FunctionComponent<ImageChoiceProps> = ({
         {question.options.map((option, index) => (
           <div
             key={index}
-            className={`${styles.checkBoxContainer} ${styles.checkboxImageContainer}`}
+            className={`${styles.checkBoxContainer} ${styles.checkboxImageContainer} ${selectedOptions.includes(index) && styles.checkboxchecked}`}
           >
+            
+            <label className={styles.checkboxLabel} htmlFor={option}>
             <input
               type="checkbox"
               name="option"
@@ -42,7 +44,6 @@ const ImageChoice: FunctionComponent<ImageChoiceProps> = ({
               className={styles.checkbox}
               checked={selectedOptions.includes(index)}
             />
-            <label className={styles.checkboxLabel} htmlFor={option}>
               <CDNImg src={option} className={styles.checkboxImage} />
             </label>
           </div>

--- a/components/quiz/questionKinds/textChoice.tsx
+++ b/components/quiz/questionKinds/textChoice.tsx
@@ -24,6 +24,8 @@ const TextChoice: FunctionComponent<TextChoiceProps> = ({
       <div className={styles.tableLayout}>
         {question.options.map((option, index) => (
           <div key={index} className={styles.checkBoxContainer}>
+           
+            <label className={`${styles.checkboxLabel} ${ selectedOptions.includes(index) && styles.checkboxchecked}`} htmlFor={option} >
             <input
               type="checkbox"
               name="option"
@@ -38,7 +40,6 @@ const TextChoice: FunctionComponent<TextChoiceProps> = ({
               className={styles.checkbox}
               checked={selectedOptions.includes(index)}
             />
-            <label className={styles.checkboxLabel} htmlFor={option}>
               {option}
             </label>
           </div>

--- a/styles/components/quests/card.module.css
+++ b/styles/components/quests/card.module.css
@@ -48,7 +48,7 @@
  
 }
 .card[aria-disabled="true"]:hover{
-  border: none;
+  border: 1px solid transparent;
 }
 
 .card[aria-disabled="true"] .cardImage,

--- a/styles/components/quests/card.module.css
+++ b/styles/components/quests/card.module.css
@@ -45,6 +45,10 @@
 
 .card[aria-disabled="true"] {
   cursor: not-allowed;
+ 
+}
+.card[aria-disabled="true"]:hover{
+  border: none;
 }
 
 .card[aria-disabled="true"] .cardImage,

--- a/styles/components/quests/quiz.module.css
+++ b/styles/components/quests/quiz.module.css
@@ -284,7 +284,6 @@
   padding: 24px 48px;
   justify-content: center;
   align-items: center;
-  /* gap: 56px; */
   flex: 1 0 0;
   opacity: 0;
   z-index: 10;

--- a/styles/components/quests/quiz.module.css
+++ b/styles/components/quests/quiz.module.css
@@ -242,10 +242,9 @@
   width: 100%;
   height: 100%;
   min-height: 180px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: 50% 50%;
+  gap: 24px;
 }
 
 .listLayout {
@@ -262,7 +261,9 @@
   display: flex;
   margin: 0 10px;
   position: relative;
-  width: calc(50% - 20px);
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
 }
 
 .listLayout .checkBoxContainer {
@@ -276,26 +277,27 @@
 }
 
 .checkbox {
+  position: absolute;
   height: 54px;
   cursor: url(../../../public/icons/pointer-cursor.png), pointer;
   display: flex;
   padding: 24px 48px;
   justify-content: center;
   align-items: center;
-  gap: 56px;
+  /* gap: 56px; */
   flex: 1 0 0;
   opacity: 0;
   z-index: 10;
 }
 
 .checkboxLabel {
-  position: absolute;
+  position: relative;
   width: 100%;
   height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 28px 16px;
+  padding: 16px 12px;
   border-radius: 10px;
   background-color: var(--background600);
   font-weight: bold;
@@ -335,6 +337,10 @@
   background-color: var(--secondary);
   color: var(--background);
 }
+.checkboxchecked{
+  background-color: var(--secondary);
+  color: var(--background);
+}
 
 .checkbox:checked+.checkboxLabel::after,
 .checkbox:checked+.checkboxLabel::before {
@@ -370,7 +376,16 @@
 .labelNumberIcon+* {
   margin-right: auto;
 }
-
+/* @media (max-width: 900px) {
+  .tableLayout{
+    grid-template-columns: 100%;
+    gap: 0;
+  }
+  .checkBoxContainer {
+    width: 100%;
+    margin: 25px 0 !important;
+  }
+} */
 @media (max-width: 600px) {
   .mainContainer {
     padding: 0 5vw 15px;
@@ -403,16 +418,19 @@
     width: calc(100% - 70px) !important;
     flex-direction: column;
     align-items: baseline;
+    margin-top: 25px;
     justify-content: baseline;
   }
 
   .checkBoxContainer {
     width: 100%;
-    margin: 25px 0 !important;
+    /* margin: 25px 0 !important; */
   }
 
   .tableLayout {
     width: 100%;
+   grid-template-columns: 100%;
+   /* gap: 0; */
   }
 
   .listLayout {

--- a/styles/components/quests/quiz.module.css
+++ b/styles/components/quests/quiz.module.css
@@ -376,16 +376,6 @@
 .labelNumberIcon+* {
   margin-right: auto;
 }
-/* @media (max-width: 900px) {
-  .tableLayout{
-    grid-template-columns: 100%;
-    gap: 0;
-  }
-  .checkBoxContainer {
-    width: 100%;
-    margin: 25px 0 !important;
-  }
-} */
 @media (max-width: 600px) {
   .mainContainer {
     padding: 0 5vw 15px;
@@ -424,13 +414,11 @@
 
   .checkBoxContainer {
     width: 100%;
-    /* margin: 25px 0 !important; */
   }
 
   .tableLayout {
     width: 100%;
    grid-template-columns: 100%;
-   /* gap: 0; */
   }
 
   .listLayout {


### PR DESCRIPTION
I eliminated the hover effect (border color) on expired quests and resolved the UI issue associated with lengthy options. Regarding the hover effect, I modified the border color to transparent when a quest is expired, as setting it to "none" would cause the card to shrink upon hovering. Additionally, I addressed a bug related to quiz options, ensuring that their height now adjusts automatically when the option length increases.
<img width="309" alt="image" src="https://github.com/starknet-id/starknet.quest/assets/86646398/cc338442-7ee4-400f-98d3-9ef514b8b788">
<img width="1440" alt="Screenshot 2024-03-12 at 10 44 43 AM" src="https://github.com/starknet-id/starknet.quest/assets/86646398/e7119f0f-e9f4-486e-9492-25def24c2255">
