### PR TITLE
feat: add post hog stats

### DIFF
--- a/app/provider.tsx
+++ b/app/provider.tsx
@@ -15,6 +15,21 @@ import { ThemeProvider, createTheme } from "@mui/material";
 import { QuestsContextProvider } from "@context/QuestsProvider";
 import { getCurrentNetwork } from "@utils/network";
 import { constants } from "starknet";
+import { PostHogProvider } from "posthog-js/react";
+import posthog from "posthog-js";
+
+// Traffic measures
+if (typeof window !== "undefined") {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY as string, {
+    api_host: "https://app.posthog.com",
+    session_recording: {
+      recordCrossOriginIframes: true,
+    },
+    capture_pageleave: false,
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).posthog = posthog;
+}
 
 export const availableConnectors = [
   new InjectedConnector({ options: { id: "braavos", name: "Braavos" } }),
@@ -37,6 +52,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
   const network = getCurrentNetwork();
   const chains = [network === "TESTNET" ? goerli : mainnet];
   const provider = jsonRpcProvider({
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     rpc: (_chain: Chain) => ({
       nodeUrl: process.env.NEXT_PUBLIC_RPC_URL as string,
     }),
@@ -67,7 +83,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
     >
       <StarknetIdJsProvider>
         <ThemeProvider theme={theme}>
-          <QuestsContextProvider>{children}</QuestsContextProvider>
+          <PostHogProvider client={posthog}>
+            <QuestsContextProvider>{children}</QuestsContextProvider>
+          </PostHogProvider>
         </ThemeProvider>
       </StarknetIdJsProvider>
     </StarknetConfig>

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "maath": "^0.7.0",
     "mongodb": "^4.12.1",
     "next": "^14.0.1",
+    "posthog-js": "^1.116.2",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
These PRs add stats to the starknet.quest website were we'll be able to monitor traffic on different pages. This should complete our stats on starknet.quest/analytics

I added the env variable on mainnet !