### PR TITLE
fix: Hide finished boosted quests after 3 weeks of expiry

### DIFF
--- a/app/quest-boost/page.tsx
+++ b/app/quest-boost/page.tsx
@@ -14,6 +14,7 @@ import { useAccount } from "@starknet-react/core";
 export default function Page() {
   const router = useRouter();
   const { address } = useAccount();
+  const MILLISECONDS_PER_WEEK = 1000 * 60 * 60 * 24 * 7;
 
   const [boosts, setBoosts] = useState<Boost[]>([]);
   const [completedQuests, setCompletedQuests] = useState<number[]>([]);
@@ -52,15 +53,20 @@ export default function Page() {
       </div>
       <h1 className={styles.title}>Boosts Quest</h1>
       <div className={styles.card_container}>
-        {boosts?.map((boost) => {
-          return (
-            <BoostCard
-              key={boost.id}
-              boost={boost}
-              completedQuests={completedQuests}
-            />
-          );
-        })}
+        {boosts
+          ?.filter(
+            (boost) =>
+              (new Date().getTime() - boost.expiry) / MILLISECONDS_PER_WEEK <= 3
+          )
+          ?.map((boost) => {
+            return (
+              <BoostCard
+                key={boost.id}
+                boost={boost}
+                completedQuests={completedQuests}
+              />
+            );
+          })}
         {boosts?.length === 0 && (
           <h2 className={styles.noBoosts}>
             No quest are being boosted at the moment.


### PR DESCRIPTION
closes #520

#Pull Request Type
1. Hide finished boosted quests 

2. Added boost quest under the collection tab
<img width="1680" alt="Screenshot 2024-04-09 at 16 43 27" src="https://github.com/starknet-id/starknet.quest/assets/105825121/28bf1b7c-260e-48fc-90cc-5e12b9daf0b6">


Please add the labels corresponding to the type of changes your PR introduces:
Refac
Bugfix

Resolves: #520 By hiding quest boosts that have exceeded 3 weeks of expiry and added boost quest under the collections tab.