### PR TITLE
fix: user cannot claim reward until all tasks have been verified

### DIFF
--- a/components/quests/questDetails.tsx
+++ b/components/quests/questDetails.tsx
@@ -402,7 +402,9 @@ const QuestDetails: FunctionComponent<QuestDetailsProps> = ({
               onClick={() => {
                 setRewardsEnabled(false);
               }}
-              disabled={!rewardsEnabled}
+              disabled={
+                !rewardsEnabled && !tasks.every((task) => task.completed)
+              }
               mintCalldata={mintCalldata}
               claimed={rewardsEnabled && unclaimedRewards?.length === 0}
               questName={quest.name}


### PR DESCRIPTION
closes #574

#Pull Request Type

user cannot claim reward until all tasks have been verified


Please add the labels corresponding to the type of changes your PR introduces:
Bugfix

Resolves: #574 By hiding disabling the Get reward button until all tasks have been verified.