### PR TITLE
test: getQuestBoostClaimParams function

### DIFF
--- a/app/quest-boost/claim/[boostId]/page.tsx
+++ b/app/quest-boost/claim/[boostId]/page.tsx
@@ -22,7 +22,7 @@ import useBoost from "@hooks/useBoost";
 import { useRouter } from "next/navigation";
 import ModalMessage from "@components/UI/modalMessage";
 import verifiedLottie from "@public/visuals/verifiedLottie.json";
-import { PendingBoostClaim } from "types/backTypes";
+import { BoostClaimParams, PendingBoostClaim } from "types/backTypes";
 
 type BoostQuestPageProps = {
   params: {
@@ -84,7 +84,10 @@ export default function Page({ params }: BoostQuestPageProps) {
     let formattedSign: Signature = ["", ""];
     try {
       if (!boost?.id || !address) return formattedSign;
-      const res = await getQuestBoostClaimParams(boost.id, address);
+      const res = await getQuestBoostClaimParams(boost?.id, address);
+      if (!res) {
+        return ["", ""];
+      }
       formattedSign = [res?.r, res?.s];
       return formattedSign;
     } catch (err) {

--- a/services/apiService.ts
+++ b/services/apiService.ts
@@ -16,6 +16,7 @@ import {
   QuestParticipantsDocument,
   UniquePageVisit,
   PendingBoostClaim,
+  BoostClaimParams,
 } from "types/backTypes";
 
 export type LeaderboardTopperParams = {
@@ -108,7 +109,7 @@ export const getQuestBoostClaimParams = async (id: number, addr: string) => {
     const response = await fetch(
       `${baseurl}/boost/get_claim_params?boost_id=${id}&addr=${addr}`
     );
-    return await response.json();
+    return (await response.json()) as BoostClaimParams;
   } catch (err) {
     console.log("Error while fetching claim signature", err);
   }

--- a/tests/services/apiService.test.js
+++ b/tests/services/apiService.test.js
@@ -17,6 +17,7 @@ import {
   getQuestsParticipation,
   updateUniqueVisitors,
   getPendingBoostClaims,
+  getQuestBoostClaimParams,
 } from "@services/apiService";
 
 const API_URL = process.env.NEXT_PUBLIC_API_LINK;
@@ -1519,6 +1520,73 @@ describe("getPendingBoostClaims function", () => {
     });
 
     const result = await getPendingBoostClaims();
+    expect(result).toEqual(mockResponse);
+  });
+});
+
+describe("getQuestBoostClaimParams function", () => {
+  beforeEach(() => {
+    fetch.mockClear();
+  });
+
+  it("should fetch and return data for a valid address and boost id", async () => {
+    const mockData = {
+      address:
+        "0x0610febaa5e58043927c8758edfaa3525ef59bac1f0b60e7b52b022084536363",
+      r: "2328575043184937723727467456938795290152111035640589440945775742296008884937",
+      s: "2314906404127565163552396326236777531502314327598120407071208784203310551837",
+    };
+
+    fetch.mockResolvedValueOnce({
+      json: () => Promise.resolve(mockData),
+    });
+
+    const result = await getQuestBoostClaimParams(
+      5,
+      "0x0610FebaA5E58043927c8758EdFAa3525Ef59bAC1f0b60E7b52b022084536363"
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      `${API_URL}/boost/get_claim_params?boost_id=5&addr=0x0610FebaA5E58043927c8758EdFAa3525Ef59bAC1f0b60E7b52b022084536363`
+    );
+    expect(result).toEqual(mockData);
+  });
+
+  it("should handle undefined cases in parameters", async () => {
+    const mockData =
+      "Failed to deserialize query string: invalid digit found in string";
+    fetch.mockResolvedValueOnce({
+      json: () => Promise.resolve(mockData),
+    });
+
+    const result = await getQuestBoostClaimParams(undefined, undefined);
+    expect(fetch).toHaveBeenCalledWith(
+      `${API_URL}/boost/get_claim_params?boost_id=undefined&addr=undefined`
+    );
+    expect(result).toEqual(mockData);
+  });
+
+  it("should handle null cases in parameters", async () => {
+    const mockData =
+      "Failed to deserialize query string: invalid digit found in string";
+    fetch.mockResolvedValueOnce({
+      json: () => Promise.resolve(mockData),
+    });
+
+    const result = await getQuestBoostClaimParams(null, null);
+    expect(fetch).toHaveBeenCalledWith(
+      `${API_URL}/boost/get_claim_params?boost_id=null&addr=null`
+    );
+    expect(result).toEqual(mockData);
+  });
+
+  it("should handle fetch errors gracefully", async () => {
+    const mockResponse =
+      "Failed to deserialize query string: missing field `boost_id`";
+    fetch.mockResolvedValueOnce({
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const result = await getQuestBoostClaimParams();
     expect(result).toEqual(mockResponse);
   });
 });

--- a/types/backTypes.d.ts
+++ b/types/backTypes.d.ts
@@ -117,7 +117,6 @@ type QuestParticipation = {
   count: number;
 }[];
 
-
 type QuizQuestionDocument = {
   kind: "text_choice" | "image_choice" | "ordering";
   layout: "default" | "illustrated_left";
@@ -140,7 +139,6 @@ type QuestActivityData = {
 type BoostedQuests = number[];
 
 type UniqueVisitorCount = number;
-
 
 type LeaderboardToppersData = {
   best_users: { address: string; xp: number; achievements: number }[];
@@ -179,4 +177,10 @@ type PendingBoostClaim = {
   name: string;
   num_of_winners: number;
   token_decimals: number;
+};
+
+type BoostClaimParams = {
+  address: string;
+  r: string;
+  s: string;
 };


### PR DESCRIPTION
# Pull Request type

getQuestBoostClaimParams function test against the following cases
- should fetch and return data for a valid address and boost id
- should handle undefined cases in parameters
- should handle null cases in parameters
- should handle fetch errors gracefully

Please add the labels corresponding to the type of changes your PR introduces:

- Testing


Resolves: #615