### PR TITLE
feat: add Dropdown component with customizable styles

### DIFF
--- a/components/UI/dropdown.tsx
+++ b/components/UI/dropdown.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import Box from '@mui/material/Box';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
-import Select, { SelectChangeEvent } from '@mui/material/Select';
+import Select from '@mui/material/Select';
+import type { SelectChangeEvent } from '@mui/material/Select'; 
 import { styled } from '@mui/system';
 
 // Define the props for the Dropdown component
@@ -11,7 +11,7 @@ type DropdownProps = {
   backgroundColor?: string;
   borderColor?: string;
   textColor?: string;
-  label: string;
+  label?: string;
   options: { value: string; label: string }[];
 };
 
@@ -24,26 +24,26 @@ const StyledFormControl = styled(FormControl, {
 })<DropdownProps>(({ theme, backgroundColor, borderColor, textColor }) => ({
   width: '100%',
   maxWidth: 300,
-  backgroundColor: backgroundColor || '#333',
-  color: textColor || '#ccc',
+  backgroundColor: backgroundColor || 'transparent',
+  color: textColor || 'inherit',
   borderRadius: 5,
   '& .MuiOutlinedInput-notchedOutline': {
-    borderColor: borderColor || '#444',
+    borderColor: borderColor || 'inherit',
   },
   '&:hover .MuiOutlinedInput-notchedOutline': {
-    borderColor: borderColor ? borderColor : '#666',
+    borderColor: borderColor ? borderColor : 'inherit',
   },
   '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-    borderColor: borderColor ? borderColor : '#666',
+    borderColor: borderColor ? borderColor : 'inherit',
   },
   '& .MuiInputLabel-root': {
-    color: textColor || '#ccc',
+    color: textColor || 'inherit',
   },
   '& .MuiInputLabel-root.Mui-focused': {
-    color: textColor || '#ccc',
+    color: textColor || 'inherit',
   },
   '& .MuiSelect-select': {
-    color: textColor || '#fff',
+    color: textColor || 'inherit',
   },
 }));
 
@@ -82,7 +82,7 @@ const Dropdown: React.FC<DropdownProps> = ({
               backgroundColor={backgroundColor}
               borderColor={borderColor}
               textColor={textColor}
-              label={''} options={[]}>
+              label={'label'} options={[]}>
         <InputLabel id="dropdown-label">{label}</InputLabel>
         <Select
           labelId="dropdown-label"

--- a/components/UI/dropdown.tsx
+++ b/components/UI/dropdown.tsx
@@ -1,17 +1,16 @@
 import * as React from 'react';
-import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import Select from '@mui/material/Select';
 import type { SelectChangeEvent } from '@mui/material/Select'; 
 import { styled } from '@mui/system';
+import { IoIosArrowDown } from "react-icons/io";
 
 // Define the props for the Dropdown component
 type DropdownProps = {
   backgroundColor?: string;
   borderColor?: string;
   textColor?: string;
-  label?: string;
   options: { value: string; label: string }[];
 };
 
@@ -21,20 +20,32 @@ const StyledFormControl = styled(FormControl, {
     prop !== 'backgroundColor' &&
     prop !== 'borderColor' &&
     prop !== 'textColor'
-})<DropdownProps>(({ theme, backgroundColor, borderColor, textColor }) => ({
-  width: '100%',
-  maxWidth: 300,
+})<DropdownProps>(({ backgroundColor, borderColor, textColor }) => ({
+  width: 150,
   backgroundColor: backgroundColor || 'transparent',
   color: textColor || 'inherit',
-  borderRadius: 5,
+  borderRadius: 10,
+  '& .MuiOutlinedInput-root': {
+    borderRadius: '10px 10px 0px 0px',
+    '& fieldset': {
+      borderColor: 'transparent',
+      borderWidth: '1px', 
+    },
+    '&:hover fieldset': {
+      borderColor: 'transparent',
+      borderWidth: '1px', 
+    },
+    '&.Mui-focused fieldset': {
+      borderColor: borderColor || 'white', 
+      borderWidth: '1px', 
+    },
+  },
   '& .MuiOutlinedInput-notchedOutline': {
-    borderColor: borderColor || 'inherit',
+    borderColor: 'transparent',
+    borderWidth: '1px', 
   },
-  '&:hover .MuiOutlinedInput-notchedOutline': {
-    borderColor: borderColor ? borderColor : 'inherit',
-  },
-  '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-    borderColor: borderColor ? borderColor : 'inherit',
+  '& .Mui-focused .MuiOutlinedInput-notchedOutline': {
+    borderColor: borderColor || 'white', 
   },
   '& .MuiInputLabel-root': {
     color: textColor || 'inherit',
@@ -44,12 +55,23 @@ const StyledFormControl = styled(FormControl, {
   },
   '& .MuiSelect-select': {
     color: textColor || 'inherit',
+    display: 'flex', 
+    alignItems: 'center', 
+  },
+  '& .MuiSelect-icon': { 
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingleft: '20px',
   },
 }));
 
 const StyledMenuItem = styled(MenuItem)(({ theme }) => ({
+  '&.Mui-selected': {
+    backgroundColor: 'transparent', 
+  },
   '&:hover': {
-    backgroundColor: '#444',
+    backgroundColor: 'transparent',
   },
 }));
 
@@ -58,47 +80,61 @@ const StyledMenuProps = {
     sx: {
       bgcolor: '#333',
       color: '#ccc',
+      borderColor: 'white',
+      borderWidth: '1px',
+      borderStyle: 'solid',
+      borderRadius: '0px 0px 10px 10px', 
+      marginTop: '-3px', 
+      boxShadow: 'none', 
+      width: '140px',
     },
   },
 };
 
 const Dropdown: React.FC<DropdownProps> = ({
   backgroundColor,
-  borderColor,
   textColor,
-  label,
   options,
 }) => {
-  const [selectedValue, setSelectedValue] = React.useState<string>('');
+  const [selectedValue, setSelectedValue] = React.useState<string>(
+    options.length > 0 ? options[0].value : ''
+  );
 
   const handleChange = (event: SelectChangeEvent) => {
     setSelectedValue(event.target.value as string);
   };
-  
+
   return (
-      <StyledFormControl
-              variant="outlined"
-              fullWidth
-              backgroundColor={backgroundColor}
-              borderColor={borderColor}
-              textColor={textColor}
-              label={'label'} options={[]}>
-        <InputLabel id="dropdown-label">{label}</InputLabel>
-        <Select
-          labelId="dropdown-label"
-          id="dropdown"
-          value={selectedValue}
-          label={label}
-          onChange={handleChange}
-          MenuProps={StyledMenuProps}
-        >
-          {options.map((option) => (
-            <StyledMenuItem key={option.value} value={option.value}>
-              {option.label}
-            </StyledMenuItem>
-          ))}
-        </Select>
-      </StyledFormControl>
+    <StyledFormControl
+      variant="outlined"
+      fullWidth
+      backgroundColor={backgroundColor}
+      textColor={textColor}
+      options={[]}
+    >
+      <Select
+        labelId="dropdown-label"
+        id="dropdown"
+        value={selectedValue}
+        onChange={handleChange}
+        MenuProps={StyledMenuProps}
+        IconComponent={() => (
+          <IoIosArrowDown style={{ color: 'white', fontSize: '50px' }} /> 
+        )}
+        inputProps={{
+          style: {
+            borderColor: 'transparent',
+            borderWidth: '1px',
+          },
+        }}
+      >
+        {options.map((option) => (
+          <StyledMenuItem key={option.value} value={option.value}>
+            {option.label}
+          </StyledMenuItem>
+        ))}
+      </Select>
+    </StyledFormControl>
   );
 };
 

--- a/components/UI/dropdown.tsx
+++ b/components/UI/dropdown.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+import { styled } from '@mui/system';
+
+// Define the props for the Dropdown component
+type DropdownProps = {
+  backgroundColor?: string;
+  borderColor?: string;
+  textColor?: string;
+  label: string;
+  options: { value: string; label: string }[];
+};
+
+// Styled component using styled-system
+const StyledFormControl = styled(FormControl, {
+  shouldForwardProp: (prop) =>
+    prop !== 'backgroundColor' &&
+    prop !== 'borderColor' &&
+    prop !== 'textColor'
+})<DropdownProps>(({ theme, backgroundColor, borderColor, textColor }) => ({
+  width: '100%',
+  maxWidth: 300,
+  backgroundColor: backgroundColor || '#333',
+  color: textColor || '#ccc',
+  borderRadius: 5,
+  '& .MuiOutlinedInput-notchedOutline': {
+    borderColor: borderColor || '#444',
+  },
+  '&:hover .MuiOutlinedInput-notchedOutline': {
+    borderColor: borderColor ? borderColor : '#666',
+  },
+  '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+    borderColor: borderColor ? borderColor : '#666',
+  },
+  '& .MuiInputLabel-root': {
+    color: textColor || '#ccc',
+  },
+  '& .MuiInputLabel-root.Mui-focused': {
+    color: textColor || '#ccc',
+  },
+  '& .MuiSelect-select': {
+    color: textColor || '#fff',
+  },
+}));
+
+const StyledMenuItem = styled(MenuItem)(({ theme }) => ({
+  '&:hover': {
+    backgroundColor: '#444',
+  },
+}));
+
+const StyledMenuProps = {
+  PaperProps: {
+    sx: {
+      bgcolor: '#333',
+      color: '#ccc',
+    },
+  },
+};
+
+const Dropdown: React.FC<DropdownProps> = ({
+  backgroundColor,
+  borderColor,
+  textColor,
+  label,
+  options,
+}) => {
+  const [selectedValue, setSelectedValue] = React.useState<string>('');
+
+  const handleChange = (event: SelectChangeEvent) => {
+    setSelectedValue(event.target.value as string);
+  };
+  
+  return (
+      <StyledFormControl
+              variant="outlined"
+              fullWidth
+              backgroundColor={backgroundColor}
+              borderColor={borderColor}
+              textColor={textColor}
+              label={''} options={[]}>
+        <InputLabel id="dropdown-label">{label}</InputLabel>
+        <Select
+          labelId="dropdown-label"
+          id="dropdown"
+          value={selectedValue}
+          label={label}
+          onChange={handleChange}
+          MenuProps={StyledMenuProps}
+        >
+          {options.map((option) => (
+            <StyledMenuItem key={option.value} value={option.value}>
+              {option.label}
+            </StyledMenuItem>
+          ))}
+        </Select>
+      </StyledFormControl>
+  );
+};
+
+export default Dropdown;

--- a/components/UI/dropdown.tsx
+++ b/components/UI/dropdown.tsx
@@ -119,7 +119,7 @@ const Dropdown: React.FC<DropdownProps> = ({
         onChange={handleChange}
         MenuProps={StyledMenuProps}
         IconComponent={() => (
-          <IoIosArrowDown style={{ color: 'white', fontSize: '50px' }} /> 
+          <IoIosArrowDown style={{ color: 'white', fontSize: '50px', padding:'0 15px 0 0'}} /> 
         )}
         inputProps={{
           style: {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

- Feature: @ayushtom This PR adds a new Dropdown component to `components/UI/dropdown.tsx` for displaying a dropdown with customizable styles.
- Resolves: #697 

## Other information

- Supports custom styles 

- Dropdown looks like:

![dropdown_1](https://github.com/starknet-id/starknet.quest/assets/87153882/b92a3c88-272c-4888-8764-c65cbd7fd694)
![dropdown_2](https://github.com/starknet-id/starknet.quest/assets/87153882/6169cec2-3fc9-4d47-a7c7-5b180e2eb9b2)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a customizable dropdown menu component, allowing users to select options from a list.
  - Added support for styling customization, including background color, border color, and text color for the dropdown menu and its items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->