### PR TITLE
Quest proposal after confirmation fixed

### DIFF
--- a/app/quest/completed/[quest-completed]/page.tsx
+++ b/app/quest/completed/[quest-completed]/page.tsx
@@ -15,7 +15,13 @@ import Quest from "@components/quests/quest";
 import Typography from "@components/UI/typography/typography";
 import { TEXT_TYPE } from "@constants/typography";
 
-export default function Page() {
+type Props = {
+  params: {
+    questId: string;
+  }
+}
+
+export default function Page({params} : Props) {
   const router = useRouter();
   const { completedQuestIds, categories } = useContext(QuestsContext);
 
@@ -23,10 +29,10 @@ export default function Page() {
     return categories.map((item) => {
       return item.quests.filter(
         (quest: { id: number; expired: boolean }) =>
-          !completedQuestIds?.includes(quest.id) && !quest.expired
+          !completedQuestIds?.includes(quest.id) && !quest.expired && quest.id !== Number(params.questId)
       );
     });
-  }, [categories, completedQuestIds]);
+  }, [categories, completedQuestIds, params.questId]);
 
   const incompleteQuests = useMemo(() => {
     return computeIncompleteQuests.flat();

--- a/components/quests/reward.tsx
+++ b/components/quests/reward.tsx
@@ -74,7 +74,7 @@ const Reward: FunctionComponent<RewardProps> = ({
         status: "pending",
       },
     });
-    router.push("/quest/completed");
+    router.push(`/quest/completed/${quest.id}`);
   }, [executeMint, address]);
 
   return (


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Small Bug Fix

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->
This PR solves the suggested quests after completing one, before the fix it was suggesting the same completed quest to be done again but it has been solved now. 
I have made the completed route dynamic now and it now takes the quest id of the completed quest as route parameter and the uncompleted quests function will now exclude the quest id in the router param.

Resolves: #714 

This PR is in continuation of #719, had to close it because of merge conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced quest completion redirection to provide more specific completion details.
  
- **Refactor**
  - Updated `Page` component to use a new `Props` type for better type safety and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->