### PR TITLE
created a custom skeleton for the defitable

### DIFF
--- a/components/discover/defiTable.tsx
+++ b/components/discover/defiTable.tsx
@@ -421,13 +421,7 @@ const DataTable: FunctionComponent<DataTableProps> = ({ data, loading }) => {
                   </TableRow>
                 ))
               ) : (
-                // <TableCell
-                //   colSpan={columns.length}
-                //   className="h-24 text-center"
-                // >
-                //   {loading ? "Loading..." : "No results"}
-                  // </TableCell>
-                  <DefiTableSkeleton />
+                <DefiTableSkeleton />
               )}
             </TableBody>
           </Table>

--- a/components/discover/defiTable.tsx
+++ b/components/discover/defiTable.tsx
@@ -33,6 +33,7 @@ import ActionText from "./actionText";
 import DownIcon from "@components/UI/iconsComponents/icons/downIcon";
 import UpIcon from "@components/UI/iconsComponents/icons/upIcon";
 import { getRedirectLink } from "@utils/defi";
+import DefiTableSkeleton from "./defiTableSkeleton";
 
 type DataTableProps = {
   data: TableInfo[];
@@ -420,12 +421,13 @@ const DataTable: FunctionComponent<DataTableProps> = ({ data, loading }) => {
                   </TableRow>
                 ))
               ) : (
-                <TableCell
-                  colSpan={columns.length}
-                  className="h-24 text-center"
-                >
-                  {loading ? "Loading..." : "No results"}
-                </TableCell>
+                // <TableCell
+                //   colSpan={columns.length}
+                //   className="h-24 text-center"
+                // >
+                //   {loading ? "Loading..." : "No results"}
+                  // </TableCell>
+                  <DefiTableSkeleton />
               )}
             </TableBody>
           </Table>

--- a/components/discover/defiTableSkeleton.tsx
+++ b/components/discover/defiTableSkeleton.tsx
@@ -10,16 +10,13 @@ import {
 import Typography from "@components/UI/typography/typography";
 import { TEXT_TYPE } from "@constants/typography";
 
-// Number of rows for the skeleton
-const numberOfRows = 10;
-
 const DefiTableSkeleton: React.FC = () => {
   return (
     <div className="w-full overflow-x-auto">
       <div className="rounded-xl border-[1px] border-[#f4faff4d] min-w-[930px] xl:w-full">
         <Table>
           <TableBody>
-            {Array.from({ length: numberOfRows }).map((_, index) => (
+            {Array.from({ length: 10 }).map((_, index) => (
               <TableRow key={index} className="animate-pulse">
                 <TableCell>
                   <div className="h-8 w-full bg-gray-300 rounded-md" />

--- a/components/discover/defiTableSkeleton.tsx
+++ b/components/discover/defiTableSkeleton.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@components/UI/table/table";
+import Typography from "@components/UI/typography/typography";
+import { TEXT_TYPE } from "@constants/typography";
+
+// Number of rows for the skeleton
+const numberOfRows = 10;
+
+const DefiTableSkeleton: React.FC = () => {
+  return (
+    <div className="w-full overflow-x-auto">
+      <div className="rounded-xl border-[1px] border-[#f4faff4d] min-w-[930px] xl:w-full">
+        <Table>
+          <TableBody>
+            {Array.from({ length: numberOfRows }).map((_, index) => (
+              <TableRow key={index} className="animate-pulse">
+                <TableCell>
+                  <div className="h-8 w-full bg-gray-300 rounded-md" />
+                </TableCell>
+                <TableCell>
+                  <div className="h-8 bg-gray-300 rounded-md" />
+                </TableCell>
+                <TableCell>
+                  <div className="h-8 bg-gray-300 rounded-md" />
+                </TableCell>
+                <TableCell>
+                  <div className="h-8 bg-gray-300 rounded-md" />
+                </TableCell>
+                <TableCell>
+                  <div className="h-8 bg-gray-300 rounded-md" />
+                </TableCell>
+                <TableCell>
+                  <div className="h-8 bg-gray-300 rounded-md" />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-center space-x-2 pt-4">
+        <div className="text-sm text-muted-foreground flex gap-8">
+          <div className="flex">
+            <Typography type={TEXT_TYPE.BODY_DEFAULT} color="white">
+              Clear All
+            </Typography>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DefiTableSkeleton;


### PR DESCRIPTION
# Pull Request type

- Feature

Resolves: #777 

- [x]  Create a defiTableSkeletong.tsx component that represents a skeleton of the size of the table (10 lines)
- [x]  Add it to defiTable.tsx
- [x]  Make sure the skeleton renders well on mobile and laptop before raising the PR

## Other information
media to show how it renders

<img width="1280" alt="Screenshot 2024-08-01 at 01 14 49" src="https://github.com/user-attachments/assets/f611e2dd-a4a9-4f8e-aba7-6d7d2eef0879">
<img width="1280" alt="Screenshot 2024-08-01 at 01 15 58" src="https://github.com/user-attachments/assets/4a42f418-5806-43ba-8bcb-8b567c6cbd42">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a `DefiTableSkeleton` component to enhance user experience during data loading with a structured loading placeholder for tables.
	- Improved visual feedback with an animated skeleton while data is being fetched, preventing empty states.
	- Added a "Clear All" button for user interaction within the loading state.
- **Bug Fixes**
	- Streamlined the rendering logic by removing previous conditional loading messages, resulting in a cleaner user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->