### PR TITLE
refac - modify 'To claim' tab logic

### DIFF
--- a/app/[addressOrDomain]/page.tsx
+++ b/app/[addressOrDomain]/page.tsx
@@ -362,9 +362,7 @@ export default function Page({ params }: AddressOrDomainProps) {
                 fontFamily: "Sora",
                 minHeight: "32px",
               }}
-              label={`To claim (${
-                claimableQuests ? claimableQuests.length : 0
-              })`}
+              label={claimableQuests && claimableQuests.length > 0 ? `To claim (${claimableQuests.length})` : ""}
               {...a11yProps(1)}
             />
           </Tabs>

--- a/app/[addressOrDomain]/page.tsx
+++ b/app/[addressOrDomain]/page.tsx
@@ -351,6 +351,7 @@ export default function Page({ params }: AddressOrDomainProps) {
               label={`Completed (${completedQuests.length})`}
               {...a11yProps(0)}
             />
+            {claimableQuests.length > 0 ? (
             <Tab
               disableRipple
               sx={{
@@ -362,9 +363,10 @@ export default function Page({ params }: AddressOrDomainProps) {
                 fontFamily: "Sora",
                 minHeight: "32px",
               }}
-              label={claimableQuests && claimableQuests.length > 0 ? `To claim (${claimableQuests.length})` : ""}
+              label={`To claim (${claimableQuests})`}
               {...a11yProps(1)}
             />
+            ) : null}
           </Tabs>
         </div>
         <CustomTabPanel value={tabIndex} index={0}>

--- a/components/pages/home/questAndCollectionTabs.tsx
+++ b/components/pages/home/questAndCollectionTabs.tsx
@@ -163,6 +163,8 @@ const QuestAndCollectionTabs: FunctionComponent<
                 {...a11yProps(1)}
               />
               {address && (
+                <>
+                {displayBoosts.length > 0 ? (    
                 <Tab
                   disableRipple
                   sx={{
@@ -174,9 +176,11 @@ const QuestAndCollectionTabs: FunctionComponent<
                     fontFamily: "Sora",
                     minHeight: "32px",
                   }}
-                  label={displayBoosts && displayBoosts.length > 0 ? `To claim (${displayBoosts.length})` : ""}
+                  label={`To claim (${displayBoosts.length})`}
                   {...a11yProps(2)}
-                />
+                /> 
+                ) : null }
+              </>
               )}
             </Tabs>
           </div>

--- a/components/pages/home/questAndCollectionTabs.tsx
+++ b/components/pages/home/questAndCollectionTabs.tsx
@@ -174,9 +174,7 @@ const QuestAndCollectionTabs: FunctionComponent<
                     fontFamily: "Sora",
                     minHeight: "32px",
                   }}
-                  label={`To claim (${
-                    displayBoosts ? displayBoosts.length : 0
-                  })`}
+                  label={displayBoosts && displayBoosts.length > 0 ? `To claim (${displayBoosts.length})` : ""}
                   {...a11yProps(2)}
                 />
               )}


### PR DESCRIPTION

- Modified To claim logic in questAndCollectionTabs.tsx 
- Modified To claim logic in addressOrDomain/page.tsx


Modify To claim logic resolves #788




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved user interface by conditionally displaying labels for claimable quests and boosts, ensuring clarity and relevance.
- **Bug Fixes**
	- Resolved issues with misleading labels for quests and boosts when none are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->