### PR TITLE
Storing TabIndex in LocalStorage for QuestAndCollectionTabs

### DIFF
--- a/components/pages/home/questAndCollectionTabs.tsx
+++ b/components/pages/home/questAndCollectionTabs.tsx
@@ -118,7 +118,7 @@ const QuestAndCollectionTabs: FunctionComponent<
     if(tempInd >= 0 && tempInd <= 2) {
       setTabIndex(tempInd);
     }
-  })
+  }, []);
 
   const completedBoostNumber = useMemo(
     () => boosts?.filter((b) => completedBoostIds?.includes(b.id)).length,

--- a/components/pages/home/questAndCollectionTabs.tsx
+++ b/components/pages/home/questAndCollectionTabs.tsx
@@ -43,6 +43,7 @@ const QuestAndCollectionTabs: FunctionComponent<
 
   const handleChangeTab = useCallback(
     (event: React.SyntheticEvent, newValue: number) => {
+      localStorage.setItem('tabIndex', newValue.toString());
       setTabIndex(newValue);
     },
     []
@@ -111,6 +112,13 @@ const QuestAndCollectionTabs: FunctionComponent<
   useEffect(() => {
     fetchBoosts();
   }, [address]);
+
+  useEffect(() => {
+    const tempInd = Number(localStorage.getItem('tabIndex'))
+    if(tempInd <= 2) {
+      setTabIndex(tempInd);
+    }
+  })
 
   const completedBoostNumber = useMemo(
     () => boosts?.filter((b) => completedBoostIds?.includes(b.id)).length,

--- a/components/pages/home/questAndCollectionTabs.tsx
+++ b/components/pages/home/questAndCollectionTabs.tsx
@@ -115,7 +115,7 @@ const QuestAndCollectionTabs: FunctionComponent<
 
   useEffect(() => {
     const tempInd = Number(localStorage.getItem('tabIndex'))
-    if(tempInd <= 2) {
+    if(tempInd >= 0 && tempInd <= 2) {
       setTabIndex(tempInd);
     }
   })


### PR DESCRIPTION
# Fixing Quests and Collections Active Tab Bug

I am using LocalStorage for storing "tabIndex" in local browser storage which gets updated whenever `handleChangeTab` function is called, I am consuming this stored tabIndex using useEffect hook, whenever the component gets mounted - I am retrieving "tabIndex" item, making necessary check of it being in range of 0 to 2 and then update the `tabIndex` state with the obtained value.

Resolves: #768 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced tab management in the Quest and Collection Tabs component with local storage support for persistent tab selection.

- **Bug Fixes**
	- Ensured previously selected tabs are restored upon page reload, improving user experience across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->