### PR TITLE
Boosts Quest Count Mismatch

### DIFF
--- a/components/pages/home/questAndCollectionTabs.tsx
+++ b/components/pages/home/questAndCollectionTabs.tsx
@@ -113,7 +113,8 @@ const QuestAndCollectionTabs: FunctionComponent<
   }, [address]);
 
   const completedBoostNumber = useMemo(
-    () => boosts?.filter((b) => completedBoostIds?.includes(b.id)).length,
+    () => boosts?.filter((b) => completedBoostIds?.includes(b.id) && ((new Date().getTime() - boost.expiry) / MILLISECONDS_PER_WEEK <= 3 &&
+          boost.expiry < Date.now())).length,
     [boosts, completedBoostIds]
   );
 
@@ -223,13 +224,13 @@ const QuestAndCollectionTabs: FunctionComponent<
                         type={TEXT_TYPE.BODY_DEFAULT}
                         className={`${styles.categoryInfosText} text-gray-200 normal-case`}
                       >
-                        {completedBoostNumber === boosts.length ? (
+                        {completedBoostNumber === displayBoosts.length ? (
                           <span className="flex">
                             <span className="mr-2">All boosts done</span>
                             <CheckIcon width="24" color="#6AFFAF" />
                           </span>
                         ) : (
-                          `${completedBoostNumber}/${boosts.length} Boost${
+                          `${completedBoostNumber}/${displayBoosts.length} Boost${
                             boosts.length > 1 ? "s" : ""
                           } done`
                         )}


### PR DESCRIPTION
# Boosts Quest Collection Display Info Mismatch Fixed

I have made necessary changes in the `components/pages/home/questAndCollectionTabs.tsx` file wherein I have modified the filter for completedBoostQuests to consider expiry of the quests. I have also changed the state to render on the page from `boosts.length` to `displayBoosts.length` to show the correct count. These changes achieve the desired fixes.

Resolves: #804 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced tracking of completed boosts by incorporating expiry checks, ensuring only recent and valid boosts are displayed. 
	- Updated user interface to accurately reflect the count of completed boosts based on new filtering criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->