### PR TITLE
Task 📝: Make the whole line clickable on the discover/defi page

### DIFF
--- a/components/discover/defiTable.tsx
+++ b/components/discover/defiTable.tsx
@@ -410,6 +410,12 @@ const DataTable: FunctionComponent<DataTableProps> = ({ data, loading }) => {
                   <TableRow
                     key={row.id}
                     data-state={row.getIsSelected() && "selected"}
+                    onClick={() =>{
+                      window.open(
+                        getRedirectLink(row.getValue("app"), row.getValue("action")),
+                        "_blank"
+                      )
+                    }}
                   >
                     {row.getVisibleCells().map((cell) => (
                       <TableCell key={cell.id}>


### PR DESCRIPTION
This Pull Request reviews the implementation of the <TableRow>, and we added a prop of type OnClick function to open the link on a separate page.

**Resolves** Issue: https://github.com/starknet-id/starknet.quest/issues/819


**Change Made**

1.  We add an Onclick function per prop to the TableRow that displays the DefiTable

**Testing:**

1. Go to the Earn tab and go to the Earn page
2. Click on any row 
3. Check if the onclick function works on all rows

**Evidence:**

https://github.com/user-attachments/assets/7d98a90d-e56b-4a9f-ade5-6a80196d13c8


Please review and let me know if any additional changes are required.

Thanks!  Dojo Coding Community Here 🥷🇨🇷

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added clickable table rows in the DataTable, allowing users to navigate to specific links associated with each row's data for improved interactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->