### PR TITLE
Fix/notifications glitch

### DIFF
--- a/components/UI/notifications/notificationDetail.tsx
+++ b/components/UI/notifications/notificationDetail.tsx
@@ -79,7 +79,7 @@ const NotificationDetail: FunctionComponent<NotificationDetailProps> = ({
     if (status !== notification.data.status) {
       updateNotificationStatus(notification.data.hash, status);
     }
-  }, [notification, isLoading, error, isError, data, status]);
+  }, [ isLoading, error, isError, data, status]);
 
   return (
     <div className={styles.notif_detail}>

--- a/hooks/useNotificationManager.ts
+++ b/hooks/useNotificationManager.ts
@@ -27,7 +27,6 @@ export function useNotificationManager() {
     );
     notifications[index].data.status = status;
     setNotifications(notifications);
-    console.log("notifications", notifications);
   };
 
   const checkTransactionStatus = async (txHash: string) => {

--- a/hooks/useNotificationManager.ts
+++ b/hooks/useNotificationManager.ts
@@ -22,11 +22,20 @@ export function useNotificationManager() {
     txHash: string,
     status: "error" | "pending" | "success"
   ) => {
-    const index = notifications.findIndex(
-      (notification) => notification.data.hash === txHash
-    );
-    notifications[index].data.status = status;
-    setNotifications(notifications);
+    const updatedNotifications = notifications.map((notification) => {
+      if (notification.data.hash === txHash) {
+        return {
+          ...notification,
+          data: {
+            ...notification.data,
+            status,
+          },
+        };
+      }
+      return notification;
+    });
+  
+    setNotifications(updatedNotifications);
   };
 
   const checkTransactionStatus = async (txHash: string) => {


### PR DESCRIPTION
**Resume**
Removed a dependency to notifications from  use effect in notification details that updates notifs status and I suggest to improve updateNotificationStatus function :)

**Ready for review**

** Bugfix**

## Other information

- I was not able to reproduce the bug each time, by replicating what actions was made in the loom video. I had to open multiple tabs with notification modal opened to have the glitch at some point.

- As I could not reproduce 100%, I am not so confident, however I thought notifications should not be a dependence to the useEffect responsible to update the notifications status fetched from useWaitForTransaction hook. As it may cause side effects with different window opened, I removed it and no glitch appeared. 

 Also I change the method updateNotificationStatus to create a new array and pass it to the set state. By Mutating the array directly and then setting it, React might not recognize that the state has changed, which could result in the UI not updating correctly. It's better to pass the updated array directly to the set state 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the dependency handling in the `NotificationDetail` component to prevent inconsistent notification status updates.

- **Improvements**
	- Enhanced the `useNotificationManager` functionality to ensure notification statuses are updated immutably, improving code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->