### PR TITLE
Feat/add disabled checkbox quest settings

### DIFF
--- a/components/admin/formSteps/QuestDetailsForm.tsx
+++ b/components/admin/formSteps/QuestDetailsForm.tsx
@@ -35,6 +35,15 @@ const QuestDetailsForm: FunctionComponent<QuestDetailsFormProps> = ({
   submitButtonDisabled,
 }) => {
   const currentUser = getUserFromJwt();
+
+  const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, checked } = e.target;
+    setQuestInput((prev: any) => ({
+      ...prev,
+      [name]: checked, 
+    }));
+  };
+
   return (
     <div className="flex flex-col gap-8">
       <div className="flex flex-col gap-1">
@@ -149,6 +158,24 @@ const QuestDetailsForm: FunctionComponent<QuestDetailsFormProps> = ({
           Choose a category that best fits the quest.
         </Typography>
       </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            name="disabled"
+            checked={questInput.disabled ?? false}
+            onChange={handleCheckboxChange} 
+            id="disabled-checkbox"
+            className={styles.customCheckbox}
+          />
+          <label htmlFor="disabled-checkbox">Disabled</label>
+        </div>
+        <Typography type={TEXT_TYPE.BODY_MICRO} color="textGray">
+          Check this box to disable the quest.
+        </Typography>
+      </div>
+
       <div className="w-full sm:w-fit">
         <Button onClick={onSubmit} disabled={submitButtonDisabled}>
           <p>Save Changes</p>

--- a/components/admin/formSteps/QuestDetailsForm.tsx
+++ b/components/admin/formSteps/QuestDetailsForm.tsx
@@ -130,7 +130,6 @@ const QuestDetailsForm: FunctionComponent<QuestDetailsFormProps> = ({
           {CATEGORY_OPTIONS.map((category) => (
             <div
               onClick={() => {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 setQuestInput((prev: any) => ({ ...prev, category }));
               }}
               key={"category" + category}

--- a/styles/admin.module.css
+++ b/styles/admin.module.css
@@ -287,3 +287,31 @@
     text-align: center;
   }
 }
+
+
+.customCheckbox {
+  position: relative;
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  -webkit-appearance: none; 
+  -moz-appearance: none;
+  appearance: none;
+  border: 2px solid #61EEE1;
+  border-radius: 3px;
+  outline: none;
+}
+
+.customCheckbox:checked {
+  background-color: #61EEE1;
+}
+
+.customCheckbox:checked::before {
+  content: "✔";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 14px;
+  color: white;
+}


### PR DESCRIPTION
## Pull Request: Add Disabled Checkbox to Quest Settings
Closes #839
This pull request implements a disabled checkbox in the `QuestDetailsForm` component located in `components/admin/formSteps/QuestDetailsForm.tsx`. The checkbox allows administrators to easily enable or disable quests through the admin dashboard.

## Changes Made
- **Added Checkbox Field**: Introduced a checkbox input that updates the `questInput` state based on whether the checkbox is ticked or unticked. This is in line with the existing implementation of other input fields.
- **Checkbox Functionality**: The checkbox is integrated in `handleCheckboxChange` working wiith the existing `handleQuestInputChange` function, ensuring that the `disabled` property in the `CreateQuest` and `UpdateQuest` types is updated correctly when the checkbox is toggled.

## Output
![image](https://github.com/user-attachments/assets/193f3382-f76b-47f5-8e73-85577c34266b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a checkbox in the Quest Details form to disable quests, enhancing user control.
- **Style**
	- Added a custom CSS class for improved checkbox appearance, including styles for checked and unchecked states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->