### PR TITLE
fix: Add spacing btw navbar and content

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -54,7 +54,7 @@ export default function RootLayout({
       <body className="default_background_color">
         <Providers>
           <Navbar />
-          <main>
+          <main className="mt-[48px]">
             {children}
           </main>
           <Footer />


### PR DESCRIPTION
# Added spacing btw navbar and content.

CSS class of 48px margin-top was added to the <main> element for styling. This implementation was added to the path: App/layout.tsx