### PR TITLE
fix: Add spacing btw navbar and content

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -54,7 +54,7 @@ export default function RootLayout({
       <body className="default_background_color">
         <Providers>
           <Navbar />
-          <main>
+          <main className="mt-[48px]">
             {children}
           </main>
           <Footer />


### PR DESCRIPTION
# Add spacing btw navbar and content

CSS style of 48px margin-top was added to the `main` element. This implementation was added to the path: App/layout.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the main content layout by adding a top margin for improved visual spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->