### PR TITLE
feat: add claim reward flow

### DIFF
--- a/components/discover/appIcon.tsx
+++ b/components/discover/appIcon.tsx
@@ -1,7 +1,23 @@
 import { CDNImg } from "@components/cdn/image";
-import React, { useCallback } from "react";
+import React, { CSSProperties, FunctionComponent, useCallback } from "react";
 
-const AppIcon = ({ app }: { app: string }) => {
+type AppIconProps = {
+  app: string;
+  imageDimensions?: {
+    width: number;
+    height: number;
+  };
+  className?: string;
+  customStyle?: CSSProperties;
+};
+
+const AppIcon: FunctionComponent<AppIconProps> = ({
+  app,
+  imageDimensions = {width: 25, height: 25},
+  className = "",
+  customStyle = {}
+}) => {
+
   const getAppLogo = useCallback((appName: string) => {
     if (appName.toLocaleLowerCase().includes("jediswap")) {
       return "/jediswap/favicon.ico";
@@ -11,14 +27,15 @@ const AppIcon = ({ app }: { app: string }) => {
     }
     return `/${appName.toLowerCase()}/favicon.ico`;
   }, []);
+
   return (
     <div className="app-icon">
       <CDNImg
-        style={{
-          borderRadius: "50%",
-        }}
+        className={className}
+        style={{borderRadius: "50%", ...customStyle}}
         loading="eager"
-        width={25}
+        width={imageDimensions.width}
+        height={imageDimensions.height}
         src={getAppLogo(app)}
         alt={app}
       />

--- a/components/discover/claimModal.tsx
+++ b/components/discover/claimModal.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { FunctionComponent } from "react";
+import { Modal } from "@mui/material";
+import styles from "@styles/components/popup.module.css";
+import Typography from "@components/UI/typography/typography";
+import Button from "@components/UI/button";
+import { CDNImg } from "@components/cdn/image";
+import { TEXT_TYPE } from "@constants/typography";
+import AppIcon from "./appIcon";
+import TokenIcon from "./tokenIcon";
+
+type rewardItem = {
+  appName: string, 
+  currencies: {currencyName: string, value: number}[]
+}
+
+type ClaimModalProps = {
+  closeModal: () => void;
+  claimRewards: () => void;
+  open: boolean;
+  rewards: rewardItem[];
+};
+
+const ClaimModal: FunctionComponent<ClaimModalProps> = ({
+  closeModal,
+  claimRewards,
+  open,
+  rewards
+}) => {
+  return (
+    <Modal
+      disableAutoFocus
+      onClose={closeModal}
+      aria-labelledby="modal-modal-title"
+      aria-describedby="modal-modal-description"
+      open={open}
+    >
+      <div className={`${styles.popup} !overflow-y-hidden !rounded-2xl !mt-0 !px-1 !py-1 md:!px-0 md:!py-0`}>
+        <div className={`${styles.popupContent} !px-0 !py-2 md:!px-12 md:!py-6`}>
+          <div className="flex w-full flex-col self-start">
+            <div className="flex w-full lg:flex-row flex-col-reverse lg:items-start items-center justify-between gap-4">
+              <div className="flex flex-col gap-4 lg:text-left text-center">
+                <Typography type={TEXT_TYPE.BODY_MIDDLE}>
+                  Collect your rewards from all supported protocols on Starknet
+                </Typography>
+                <Typography type={TEXT_TYPE.H4}>
+                  Claim Your Rewards
+                </Typography>
+              </div>
+              <CDNImg
+                src="/icons/strk.webp"
+                alt="starknet icon"
+                className="border border-white rounded-full w-12 h-12 aspect-square"
+                style={{ transform: "rotateY(190deg)" }}
+              />
+            </div>
+            <div className="flex w-full flex-col mt-4 max-h-80 overflow-auto">
+              {rewards.map((item, index) => (
+                <div
+                  key={index}
+                  className="flex w-full justify-between items-center bg-background px-2 py-3 my-1 rounded-lg"
+                >
+                  <div className="flex flex-row gap-4">
+                    <AppIcon
+                      app={item.appName}
+                    />
+                    <Typography type={TEXT_TYPE.BODY_MIDDLE}>
+                      {item.appName}
+                    </Typography>
+                  </div>
+                  <div className="flex w-fit flex-col items-end">
+                    {item.currencies.map((currency, idx) => (
+                      <div key={idx} className="flex flex-row items-center gap-4">
+                        <Typography type={TEXT_TYPE.BODY_SMALL}>
+                          {currency.value < 1000 ? currency.value : `${currency.value / 1000}K`}
+                        </Typography>
+                        <Typography type={TEXT_TYPE.BODY_SMALL}>
+                          {currency.currencyName}
+                        </Typography>
+                        <TokenIcon
+                          token={currency.currencyName}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className={`${styles.bottomContent} !gap-6 !py-6 !px-5`}>
+          <div className="flex w-full justify-between items-center">
+            <div className="modified-cursor-pointer" onClick={() => closeModal()}>
+              <Typography type={TEXT_TYPE.BODY_MIDDLE}>
+                Cancel
+              </Typography>
+            </div>
+            <div className="w-fit">
+              <Button
+                onClick={() => claimRewards()}
+              >
+                Claim all
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ClaimModal;
+

--- a/components/discover/claimModal.tsx
+++ b/components/discover/claimModal.tsx
@@ -159,9 +159,9 @@ const ClaimModal: FunctionComponent<ClaimModalProps> = ({
     >
       <div className={`${styles.popup} !overflow-y-hidden !rounded-2xl !mt-0 !px-1 !py-1 md:!px-0 md:!py-0`}>
         <Loading isLoading={loading} loadingType="spinner">
-          <div className={`${styles.popupContent} !px-0 !py-2 md:!px-12 md:!py-6`}>
+          <div className={`${styles.popupContent} !px-0 !pt-6 !pb-0 md:!px-12 md:!pt-14`}>
             <div className="flex w-full flex-col self-start">
-              <div className="flex w-full lg:flex-row flex-col-reverse lg:items-start items-center justify-between gap-4">
+              <div className="flex w-full lg:flex-row flex-col-reverse lg:items-start items-center justify-between gap-4 md:pb-2">
                 <div className="flex flex-col gap-4 lg:text-left text-center">
                   <Typography type={TEXT_TYPE.BODY_MIDDLE}>
                     Collect your rewards from all supported protocols on Starknet

--- a/components/discover/claimModal.tsx
+++ b/components/discover/claimModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { FunctionComponent } from "react";
 import { Modal } from "@mui/material";
 import styles from "@styles/components/popup.module.css";
@@ -8,10 +8,12 @@ import { CDNImg } from "@components/cdn/image";
 import { TEXT_TYPE } from "@constants/typography";
 import AppIcon from "./appIcon";
 import TokenIcon from "./tokenIcon";
+import { useNotification } from "@context/NotificationProvider";
+import Loading from "@app/loading";
 
 type RewardItem = {
-  appName: string, 
-  currencies: {currencyName: string, value: number}[]
+  appName: string,
+  currencies: { currencyName: string, value: number }[]
 }
 
 type CurrencyRowProps = {
@@ -21,12 +23,11 @@ type CurrencyRowProps = {
 
 type ClaimModalProps = {
   closeModal: () => void;
-  claimRewards: () => void;
+  showSuccess: () => void;
   open: boolean;
-  rewards: RewardItem[];
 };
 
-const RewardComponent: FunctionComponent<RewardItem> = ({appName, currencies}) => (
+const RewardComponent: FunctionComponent<RewardItem> = ({ appName, currencies }) => (
   <div className="flex w-full justify-between items-center bg-background px-2 py-3 my-1 rounded-lg">
     <div className="flex flex-row gap-4">
       <AppIcon app={appName} />
@@ -42,7 +43,7 @@ const RewardComponent: FunctionComponent<RewardItem> = ({appName, currencies}) =
   </div>
 );
 
-const CurrencyRow: FunctionComponent<CurrencyRowProps> = ({currencyName, currencyValue}) => (
+const CurrencyRow: FunctionComponent<CurrencyRowProps> = ({ currencyName, currencyValue }) => (
   <div className="flex flex-row items-center gap-4">
     <Typography type={TEXT_TYPE.BODY_SMALL}>
       {currencyValue < 1000 ? currencyValue : `${currencyValue / 1000}K`}
@@ -56,10 +57,99 @@ const CurrencyRow: FunctionComponent<CurrencyRowProps> = ({currencyName, currenc
 
 const ClaimModal: FunctionComponent<ClaimModalProps> = ({
   closeModal,
-  claimRewards,
-  open,
-  rewards
+  showSuccess,
+  open
 }) => {
+  const [claimRewards, setClaimRewards] = useState<RewardItem[]>();
+  const [loading, setLoading] = useState<boolean>(true);
+  const { showNotification } = useNotification();
+
+  const getClaimRewards = useCallback(async () => {
+    // TODO: Implement fetch from backend. Returning mock values.
+    try {
+      setLoading(true);
+      const rewards = [
+        {
+          appName: "EKUBO",
+          currencies: [
+            { currencyName: "STRK", value: 11570 }
+          ],
+        },
+        {
+          appName: "NOSTRA",
+          currencies: [
+            { currencyName: "STRK", value: 12.124 },
+            { currencyName: "ETH", value: 1.1245 }
+          ],
+        },
+        {
+          appName: "zkLend",
+          currencies: [
+            { currencyName: "USDT", value: 124.12 }
+          ],
+        },
+        {
+          appName: "VESU",
+          currencies: [
+            { currencyName: "STRK", value: 36 }
+          ],
+        },
+        {
+          appName: "Nimbora",
+          currencies: [
+            { currencyName: "STRK", value: 70.145 }
+          ],
+        },
+        {
+          appName: "zkLend",
+          currencies: [
+            { currencyName: "USDT", value: 124.12 }
+          ],
+        },
+        {
+          appName: "VESU",
+          currencies: [
+            { currencyName: "STRK", value: 36 }
+          ],
+        },
+        {
+          appName: "Nimbora",
+          currencies: [
+            { currencyName: "STRK", value: 70.145 }
+          ],
+        },
+      ];
+      const res = await new Promise<RewardItem[]>(resolve => setTimeout(() => resolve(rewards), 2000));
+      setClaimRewards(res);
+      setLoading(false);
+    } catch (error) {
+      setLoading(false);
+      showNotification("Error while fetching rewards", "error");
+      console.log("Error while fetching rewards", error);
+    }
+  }, []);
+
+  const doClaimRewards = useCallback(async () => {
+    // TODO: Implement logic to claim rewards
+    try {
+      setLoading(true);
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      setLoading(false);
+      closeModal();
+      showSuccess();
+    } catch (error) {
+      setLoading(false);
+      showNotification("Error while claiming rewards", "error");
+      console.log("Error while claiming rewards", error);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      getClaimRewards();
+    }
+  }, [open, getClaimRewards]);
+
   return (
     <Modal
       disableAutoFocus
@@ -68,47 +158,53 @@ const ClaimModal: FunctionComponent<ClaimModalProps> = ({
       open={open}
     >
       <div className={`${styles.popup} !overflow-y-hidden !rounded-2xl !mt-0 !px-1 !py-1 md:!px-0 md:!py-0`}>
-        <div className={`${styles.popupContent} !px-0 !py-2 md:!px-12 md:!py-6`}>
-          <div className="flex w-full flex-col self-start">
-            <div className="flex w-full lg:flex-row flex-col-reverse lg:items-start items-center justify-between gap-4">
-              <div className="flex flex-col gap-4 lg:text-left text-center">
-                <Typography type={TEXT_TYPE.BODY_MIDDLE}>
-                  Collect your rewards from all supported protocols on Starknet
-                </Typography>
-                <Typography type={TEXT_TYPE.H4}>
-                  Claim Your Rewards
-                </Typography>
+        <Loading isLoading={loading} loadingType="spinner">
+          <div className={`${styles.popupContent} !px-0 !py-2 md:!px-12 md:!py-6`}>
+            <div className="flex w-full flex-col self-start">
+              <div className="flex w-full lg:flex-row flex-col-reverse lg:items-start items-center justify-between gap-4">
+                <div className="flex flex-col gap-4 lg:text-left text-center">
+                  <Typography type={TEXT_TYPE.BODY_MIDDLE}>
+                    Collect your rewards from all supported protocols on Starknet
+                  </Typography>
+                  <Typography type={TEXT_TYPE.H4}>
+                    Claim Your Rewards
+                  </Typography>
+                </div>
+                <CDNImg
+                  src="/icons/strk.webp"
+                  alt="starknet icon"
+                  aria-label="Starknet logo"
+                  className="border border-white rounded-full w-12 h-12 aspect-square"
+                  style={{ transform: "rotateY(190deg)" }}
+                />
               </div>
-              <CDNImg
-                src="/icons/strk.webp"
-                alt="starknet icon"
-                className="border border-white rounded-full w-12 h-12 aspect-square"
-                style={{ transform: "rotateY(190deg)" }}
-              />
-            </div>
-            <div className="flex w-full flex-col mt-4 max-h-80 overflow-auto">
-              {rewards.map((item, index) => (
-                <RewardComponent key={index} appName={item.appName} currencies={item.currencies} />
-              ))}
+              <div className="flex w-full flex-col mt-4 max-h-80 overflow-auto">
+                {!claimRewards ?
+                  <Typography type={TEXT_TYPE.BODY_DEFAULT}>No rewards available</Typography>
+                  :
+                  claimRewards.map((item, index) => (
+                    <RewardComponent key={index} appName={item.appName} currencies={item.currencies} />
+                  ))}
+              </div>
             </div>
           </div>
-        </div>
-        <div className={`${styles.bottomContent} !gap-6 !py-6 !px-5`}>
-          <div className="flex w-full justify-between items-center">
-            <button onClick={() => closeModal()} aria-label="Cancel claiming rewards">
-              <Typography type={TEXT_TYPE.BODY_MIDDLE}>
-                Cancel
-              </Typography>
-            </button>
-            <div className="w-fit">
-              <Button
-                onClick={() => claimRewards()}
-              >
-                Claim all
-              </Button>
+          <div className={`${styles.bottomContent} !gap-6 !py-6 !px-5`}>
+            <div className="flex w-full justify-between items-center">
+              <button onClick={closeModal} aria-label="Cancel claiming rewards">
+                <Typography type={TEXT_TYPE.BODY_MIDDLE}>
+                  Cancel
+                </Typography>
+              </button>
+              <div className="w-fit">
+                <Button disabled={claimRewards ? false : true}
+                  onClick={doClaimRewards}
+                >
+                  Claim all
+                </Button>
+              </div>
             </div>
           </div>
-        </div>
+        </Loading>
       </div>
     </Modal>
   );

--- a/components/discover/claimModal.tsx
+++ b/components/discover/claimModal.tsx
@@ -9,17 +9,50 @@ import { TEXT_TYPE } from "@constants/typography";
 import AppIcon from "./appIcon";
 import TokenIcon from "./tokenIcon";
 
-type rewardItem = {
+type RewardItem = {
   appName: string, 
   currencies: {currencyName: string, value: number}[]
+}
+
+type CurrencyRowProps = {
+  currencyName: string;
+  currencyValue: number;
 }
 
 type ClaimModalProps = {
   closeModal: () => void;
   claimRewards: () => void;
   open: boolean;
-  rewards: rewardItem[];
+  rewards: RewardItem[];
 };
+
+const RewardComponent: FunctionComponent<RewardItem> = ({appName, currencies}) => (
+  <div className="flex w-full justify-between items-center bg-background px-2 py-3 my-1 rounded-lg">
+    <div className="flex flex-row gap-4">
+      <AppIcon app={appName} />
+      <Typography type={TEXT_TYPE.BODY_MIDDLE}>
+        {appName}
+      </Typography>
+    </div>
+    <div className="flex w-fit flex-col items-end">
+      {currencies.map((currency, idx) => (
+        <CurrencyRow key={idx} currencyName={currency.currencyName} currencyValue={currency.value} />
+      ))}
+    </div>
+  </div>
+);
+
+const CurrencyRow: FunctionComponent<CurrencyRowProps> = ({currencyName, currencyValue}) => (
+  <div className="flex flex-row items-center gap-4">
+    <Typography type={TEXT_TYPE.BODY_SMALL}>
+      {currencyValue < 1000 ? currencyValue : `${currencyValue / 1000}K`}
+    </Typography>
+    <Typography type={TEXT_TYPE.BODY_SMALL}>
+      {currencyName}
+    </Typography>
+    <TokenIcon token={currencyName} />
+  </div>
+);
 
 const ClaimModal: FunctionComponent<ClaimModalProps> = ({
   closeModal,
@@ -31,8 +64,7 @@ const ClaimModal: FunctionComponent<ClaimModalProps> = ({
     <Modal
       disableAutoFocus
       onClose={closeModal}
-      aria-labelledby="modal-modal-title"
-      aria-describedby="modal-modal-description"
+      aria-label="Reward claim success modal"
       open={open}
     >
       <div className={`${styles.popup} !overflow-y-hidden !rounded-2xl !mt-0 !px-1 !py-1 md:!px-0 md:!py-0`}>
@@ -56,45 +88,18 @@ const ClaimModal: FunctionComponent<ClaimModalProps> = ({
             </div>
             <div className="flex w-full flex-col mt-4 max-h-80 overflow-auto">
               {rewards.map((item, index) => (
-                <div
-                  key={index}
-                  className="flex w-full justify-between items-center bg-background px-2 py-3 my-1 rounded-lg"
-                >
-                  <div className="flex flex-row gap-4">
-                    <AppIcon
-                      app={item.appName}
-                    />
-                    <Typography type={TEXT_TYPE.BODY_MIDDLE}>
-                      {item.appName}
-                    </Typography>
-                  </div>
-                  <div className="flex w-fit flex-col items-end">
-                    {item.currencies.map((currency, idx) => (
-                      <div key={idx} className="flex flex-row items-center gap-4">
-                        <Typography type={TEXT_TYPE.BODY_SMALL}>
-                          {currency.value < 1000 ? currency.value : `${currency.value / 1000}K`}
-                        </Typography>
-                        <Typography type={TEXT_TYPE.BODY_SMALL}>
-                          {currency.currencyName}
-                        </Typography>
-                        <TokenIcon
-                          token={currency.currencyName}
-                        />
-                      </div>
-                    ))}
-                  </div>
-                </div>
+                <RewardComponent key={index} appName={item.appName} currencies={item.currencies} />
               ))}
             </div>
           </div>
         </div>
         <div className={`${styles.bottomContent} !gap-6 !py-6 !px-5`}>
           <div className="flex w-full justify-between items-center">
-            <div className="modified-cursor-pointer" onClick={() => closeModal()}>
+            <button onClick={() => closeModal()} aria-label="Cancel claiming rewards">
               <Typography type={TEXT_TYPE.BODY_MIDDLE}>
                 Cancel
               </Typography>
-            </div>
+            </button>
             <div className="w-fit">
               <Button
                 onClick={() => claimRewards()}
@@ -110,4 +115,3 @@ const ClaimModal: FunctionComponent<ClaimModalProps> = ({
 };
 
 export default ClaimModal;
-

--- a/components/discover/defiTable.tsx
+++ b/components/discover/defiTable.tsx
@@ -323,8 +323,8 @@ const DataTable: FunctionComponent<DataTableProps> = ({ data, loading }) => {
           </div>
           <div
             onClick={() => setShowClaimModal(true)}
-            className="flex flex-row items-center justify-evenly gap-4 bg-white rounded-lg modified-cursor-pointer h-min lg:mt-2 mt-8 px-4 lg:py-1 py-2">
-            <AppIcon app="starknet" />
+            className="flex flex-row items-center justify-evenly gap-4 bg-white rounded-xl modified-cursor-pointer h-min lg:mt-2 mt-8 px-6 py-2.5">
+            <AppIcon app="starknet" className="w-5 h-5" />
             <Typography type={TEXT_TYPE.BUTTON_LARGE} color="background">
               Claim all
             </Typography>

--- a/components/discover/defiTable.tsx
+++ b/components/discover/defiTable.tsx
@@ -158,15 +158,15 @@ export const columns: ColumnDef<TableInfo>[] = [
     accessorKey: "apr",
     header: () => (
       <div className="flex items-center modified-cursor-pointer w-full h-full">
-      <div className="flex flex-row gap-2 items-center">
-        <Typography type={TEXT_TYPE.BODY_SMALL} color="textGray">
-          APR
-        </Typography>
-        <div className="flex flex-col gap-0">
-          <DownIcon width="10" color="#a6a5a7" />
-          <UpIcon width="10" color="#a6a5a7" />
+        <div className="flex flex-row gap-2 items-center">
+          <Typography type={TEXT_TYPE.BODY_SMALL} color="textGray">
+            APR
+          </Typography>
+          <div className="flex flex-col gap-0">
+            <DownIcon width="10" color="#a6a5a7" />
+            <UpIcon width="10" color="#a6a5a7" />
+          </div>
         </div>
-      </div>
       </div>
     ),
     cell: ({ row }) => {
@@ -178,19 +178,19 @@ export const columns: ColumnDef<TableInfo>[] = [
     accessorKey: "volume",
     header: () => (
       <div className="flex items-center modified-cursor-pointer w-full h-full">
-      <div className="flex flex-row gap-2 items-center">
-        <Typography type={TEXT_TYPE.BODY_SMALL} color="textGray">
-          TVL
-        </Typography>
-        <div className="flex flex-col gap-0">
-          <div>
-            <DownIcon width="10" color="#a6a5a7" />
-          </div>
-          <div>
-            <UpIcon width="10" color="#a6a5a7" />
+        <div className="flex flex-row gap-2 items-center">
+          <Typography type={TEXT_TYPE.BODY_SMALL} color="textGray">
+            TVL
+          </Typography>
+          <div className="flex flex-col gap-0">
+            <div>
+              <DownIcon width="10" color="#a6a5a7" />
+            </div>
+            <div>
+              <UpIcon width="10" color="#a6a5a7" />
+            </div>
           </div>
         </div>
-      </div>
       </div>
     ),
     cell: ({ row }) => {
@@ -211,15 +211,15 @@ export const columns: ColumnDef<TableInfo>[] = [
     accessorKey: "daily_rewards",
     header: () => (
       <div className="flex items-center modified-cursor-pointer w-full h-full">
-      <div className="flex flex-row gap-2 items-center justify-end">
-        <Typography type={TEXT_TYPE.BODY_SMALL} color="textGray">
-          Daily Rewards
-        </Typography>
-        <div className="flex flex-col gap-0">
-          <DownIcon width="10" color="#a6a5a7" />
-          <UpIcon width="10" color="#a6a5a7" />
+        <div className="flex flex-row gap-2 items-center justify-end">
+          <Typography type={TEXT_TYPE.BODY_SMALL} color="textGray">
+            Daily Rewards
+          </Typography>
+          <div className="flex flex-col gap-0">
+            <DownIcon width="10" color="#a6a5a7" />
+            <UpIcon width="10" color="#a6a5a7" />
+          </div>
         </div>
-      </div>
       </div>
     ),
     cell: ({ row }) => {
@@ -251,9 +251,10 @@ const DataTable: FunctionComponent<DataTableProps> = ({ data, loading }) => {
   const [liquidityFilter, setLiquidityFilter] = useState<string>();
   const [securityFilter, setSecurityFilter] = useState<string>();
   const [airdropFilter, setAirdropFilter] = useState<string>();
-  const [showClaimModal, setShowClaimModal] = useState<boolean>(false);
-  const [showSuccessModal, setShowSuccessModal] = useState<boolean>(false);
 
+  const [showClaimModal, setShowClaimModal] = useState(false);
+  const [showSuccessModal, setShowSuccessModal] = useState(false);
+  
   const table = useReactTable({
     data,
     columns,
@@ -308,61 +309,6 @@ const DataTable: FunctionComponent<DataTableProps> = ({ data, loading }) => {
     table.resetColumnFilters();
   }, [table]);
 
-  const getClaimRewards = useCallback(() => {
-    // TODO: Implement fetch from backend. Returning mock values.
-    return [
-      {
-        appName: "EKUBO", 
-        currencies: [
-          {currencyName: "STRK", value: 11570}
-        ],
-      },
-      {
-        appName: "NOSTRA", 
-        currencies: [
-          {currencyName: "STRK", value: 12.124},
-          {currencyName: "ETH", value: 1.1245}
-        ],
-      },
-      {
-        appName: "zkLend", 
-        currencies: [
-          {currencyName: "USDT", value: 124.12}
-        ],
-      },
-      {
-        appName: "VESU", 
-        currencies: [
-          {currencyName: "STRK", value: 36}
-        ],
-      },
-      {
-        appName: "Nimbora", 
-        currencies: [
-          {currencyName: "STRK", value: 70.145}
-        ],
-      },
-      {
-        appName: "zkLend", 
-        currencies: [
-          {currencyName: "USDT", value: 124.12}
-        ],
-      },
-      {
-        appName: "VESU", 
-        currencies: [
-          {currencyName: "STRK", value: 36}
-        ],
-      },
-      {
-        appName: "Nimbora", 
-        currencies: [
-          {currencyName: "STRK", value: 70.145}
-        ],
-      },
-    ];
-  }, []);
-
   return (
     <div className="w-full overflow-x-auto">
       <div className="">
@@ -378,7 +324,7 @@ const DataTable: FunctionComponent<DataTableProps> = ({ data, loading }) => {
           <div
             onClick={() => setShowClaimModal(true)}
             className="flex flex-row items-center justify-evenly gap-4 bg-white rounded-lg modified-cursor-pointer h-min lg:mt-2 mt-8 px-4 lg:py-1 py-2">
-            <AppIcon app="starknet"/>
+            <AppIcon app="starknet" />
             <Typography type={TEXT_TYPE.BUTTON_LARGE} color="background">
               Claim all
             </Typography>
@@ -386,14 +332,10 @@ const DataTable: FunctionComponent<DataTableProps> = ({ data, loading }) => {
         </div>
         <ClaimModal
           open={showClaimModal}
-          rewards={getClaimRewards()}
           closeModal={() => setShowClaimModal(false)}
-          claimRewards={() => {
-            setShowClaimModal(false);
-            setShowSuccessModal(true);
-          }}
+          showSuccess={() => setShowSuccessModal(true)}
         />
-        <SuccessModal 
+        <SuccessModal
           open={showSuccessModal}
           closeModal={() => setShowSuccessModal(false)}
         />
@@ -476,9 +418,9 @@ const DataTable: FunctionComponent<DataTableProps> = ({ data, loading }) => {
                         {header.isPlaceholder
                           ? null
                           : flexRender(
-                              header.column.columnDef.header,
-                              header.getContext()
-                            )}
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
                       </TableHead>
                     );
                   })}
@@ -491,7 +433,7 @@ const DataTable: FunctionComponent<DataTableProps> = ({ data, loading }) => {
                   <TableRow
                     key={row.id}
                     data-state={row.getIsSelected() && "selected"}
-                    onClick={() =>{
+                    onClick={() => {
                       window.open(
                         getRedirectLink(row.getValue("app"), row.getValue("action")),
                         "_blank"
@@ -521,7 +463,7 @@ const DataTable: FunctionComponent<DataTableProps> = ({ data, loading }) => {
               onClick={() =>
                 table.getCanPreviousPage() ? table.previousPage() : null
               }
-              style= {table.getCanPreviousPage() ? {} : {cursor:'not-allowed' } }
+              style={table.getCanPreviousPage() ? {} : { cursor: 'not-allowed' }}
             >
               <CDNImage
                 src="/icons/chevronLeft.svg"
@@ -533,7 +475,7 @@ const DataTable: FunctionComponent<DataTableProps> = ({ data, loading }) => {
             <div
               className="flex modified-cursor-pointer"
               onClick={() => (table.getCanNextPage() ? table.nextPage() : null)}
-              style= {table.getCanNextPage() ? {} : {cursor:'not-allowed' } }
+              style={table.getCanNextPage() ? {} : { cursor: 'not-allowed' }}
             >
               <CDNImage
                 src="/icons/chevronRight.svg"

--- a/components/discover/defiTable.tsx
+++ b/components/discover/defiTable.tsx
@@ -34,6 +34,8 @@ import DownIcon from "@components/UI/iconsComponents/icons/downIcon";
 import UpIcon from "@components/UI/iconsComponents/icons/upIcon";
 import { getRedirectLink } from "@utils/defi";
 import DefiTableSkeleton from "./defiTableSkeleton";
+import ClaimModal from "./claimModal";
+import SuccessModal from "./successModal";
 
 type DataTableProps = {
   data: TableInfo[];
@@ -249,6 +251,8 @@ const DataTable: FunctionComponent<DataTableProps> = ({ data, loading }) => {
   const [liquidityFilter, setLiquidityFilter] = useState<string>();
   const [securityFilter, setSecurityFilter] = useState<string>();
   const [airdropFilter, setAirdropFilter] = useState<string>();
+  const [showClaimModal, setShowClaimModal] = useState<boolean>(false);
+  const [showSuccessModal, setShowSuccessModal] = useState<boolean>(false);
 
   const table = useReactTable({
     data,
@@ -289,11 +293,13 @@ const DataTable: FunctionComponent<DataTableProps> = ({ data, loading }) => {
     setSecurityFilter(e.target.value);
     column?.setFilterValue(e.target.value);
   }, []);
+
   const handleAirdropFilter = useCallback((e: SelectChangeEvent) => {
     const column = table.getColumn("app");
     setAirdropFilter(e.target.value);
     column?.setFilterValue(e.target.value);
   }, []);
+
   const resetFilters = useCallback(() => {
     setLiquidityFilter("");
     setTokenFilter("");
@@ -302,17 +308,95 @@ const DataTable: FunctionComponent<DataTableProps> = ({ data, loading }) => {
     table.resetColumnFilters();
   }, [table]);
 
+  const getClaimRewards = useCallback(() => {
+    // TODO: Implement fetch from backend. Returning mock values.
+    return [
+      {
+        appName: "EKUBO", 
+        currencies: [
+          {currencyName: "STRK", value: 11570}
+        ],
+      },
+      {
+        appName: "NOSTRA", 
+        currencies: [
+          {currencyName: "STRK", value: 12.124},
+          {currencyName: "ETH", value: 1.1245}
+        ],
+      },
+      {
+        appName: "zkLend", 
+        currencies: [
+          {currencyName: "USDT", value: 124.12}
+        ],
+      },
+      {
+        appName: "VESU", 
+        currencies: [
+          {currencyName: "STRK", value: 36}
+        ],
+      },
+      {
+        appName: "Nimbora", 
+        currencies: [
+          {currencyName: "STRK", value: 70.145}
+        ],
+      },
+      {
+        appName: "zkLend", 
+        currencies: [
+          {currencyName: "USDT", value: 124.12}
+        ],
+      },
+      {
+        appName: "VESU", 
+        currencies: [
+          {currencyName: "STRK", value: 36}
+        ],
+      },
+      {
+        appName: "Nimbora", 
+        currencies: [
+          {currencyName: "STRK", value: 70.145}
+        ],
+      },
+    ];
+  }, []);
+
   return (
     <div className="w-full overflow-x-auto">
       <div className="">
-        <div className={`flex w-100 flex-col gap-2`}>
-          <Typography type={TEXT_TYPE.H4} color="secondary">
-            Explore reward opportunities
-          </Typography>
-          <Typography type={TEXT_TYPE.BODY_MICRO} color="secondary">
-            Find the best opportunities, and earn tokens
-          </Typography>
+        <div className={`flex w-100 lg:flex-row flex-col justify-between items-start`}>
+          <div className={`flex w-100 flex-col gap-2`}>
+            <Typography type={TEXT_TYPE.H4} color="secondary">
+              Explore reward opportunities
+            </Typography>
+            <Typography type={TEXT_TYPE.BODY_MICRO} color="secondary">
+              Find the best opportunities, and earn tokens
+            </Typography>
+          </div>
+          <div
+            onClick={() => setShowClaimModal(true)}
+            className="flex flex-row items-center justify-evenly gap-4 bg-white rounded-lg modified-cursor-pointer h-min lg:mt-2 mt-8 px-4 lg:py-1 py-2">
+            <AppIcon app="starknet"/>
+            <Typography type={TEXT_TYPE.BUTTON_LARGE} color="background">
+              Claim all
+            </Typography>
+          </div>
         </div>
+        <ClaimModal
+          open={showClaimModal}
+          rewards={getClaimRewards()}
+          closeModal={() => setShowClaimModal(false)}
+          claimRewards={() => {
+            setShowClaimModal(false);
+            setShowSuccessModal(true);
+          }}
+        />
+        <SuccessModal 
+          open={showSuccessModal}
+          closeModal={() => setShowSuccessModal(false)}
+        />
         <div className="flex xl:flex-row flex-col sm:justify-between gap-4 justify-center items-center py-4 xl:py-0">
           <div className="w-full gap-4 flex flex-row py-4 flex-wrap xl:flex-nowrap justify-center lg:justify-start">
             <div className="w-full lg:w-fit">

--- a/components/discover/successModal.tsx
+++ b/components/discover/successModal.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { FunctionComponent } from "react";
+import { Modal } from "@mui/material";
+import styles from "@styles/components/popup.module.css";
+import { CDNImg } from "@components/cdn/image";
+import { TEXT_TYPE } from "@constants/typography";
+import Typography from "@components/UI/typography/typography";
+import Button from "@components/UI/button";
+
+type SuccessModalProps = {
+  closeModal: () => void;
+  open: boolean;
+};
+
+const SuccessModal: FunctionComponent<SuccessModalProps> = ({
+  closeModal,
+  open
+}) => {
+  return (
+    <Modal
+      disableAutoFocus
+      onClose={closeModal}
+      aria-labelledby="modal-modal-title"
+      aria-describedby="modal-modal-description"
+      open={open}
+    >
+      <div className={`${styles.popup} !overflow-y-hidden !rounded-2xl !mt-0 !px-4 !py-4 md:!py-0 md:!px-0`}>
+        <div className={`${styles.popupContent} !px-1 !py-3 md:!px-12 md:!py-8`}>
+          <div className="flex w-fit flex-col items-center text-center">
+            <Typography type={TEXT_TYPE.H4}>
+              You've claimed all your rewards with success!
+            </Typography>
+            <CDNImg
+              src="/icons/success.svg"
+              alt="success icon"
+              width={256}
+              height={256}
+              className="object-contain"
+            />
+          </div>
+        </div>
+        <div className={`${styles.bottomContent} !gap-6 !py-6 !px-5`}>
+          <div className="flex w-fit items-center">
+            <Button onClick={closeModal}>Thanks</Button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default SuccessModal;

--- a/components/discover/tokenIcon.tsx
+++ b/components/discover/tokenIcon.tsx
@@ -16,15 +16,28 @@ const TokenIcon: FunctionComponent<TokenIconProps> = ({
   customStyle = {}
 }) => {
 
-  const getTokenIcon = useCallback((tokenName: string) => {
-    if (tokenName.toUpperCase() === "USDC") return "/icons/usdc.svg";
-    if (tokenName.toUpperCase() === "ETH") return "/icons/eth.svg";
-    if (tokenName.toUpperCase() === "LORDS") return "/icons/lords.webp";
-    if (tokenName.toUpperCase() === "SITH") return "/icons/sith.png";
-    if (tokenName.toUpperCase() === "STRK") return "/icons/strk.webp";
+  const tokenIconMap: { [key: string]: string } = {
+    USDC: "/icons/usdc.svg",
+    ETH: "/icons/eth.svg",
+    LORDS: "/icons/lords.webp",
+    SITH: "/icons/sith.png",
+    STRK: "/icons/strk.webp",
+  };
 
-    return "/icons/usdc.svg";
+  const getTokenIcon = useCallback((tokenName: string) => {
+    return tokenIconMap[tokenName.toUpperCase()] || "/icons/usdc.svg";
   }, []);
+
+  const getTokenStyle = (token: string, customStyle: CSSProperties = {}) => {
+    const specialStyles: Record<string, CSSProperties> = {
+      STRK: { transform: "rotateY(180deg)" }, // webp is mirrored, so need to flip it to be displayed correctly.
+    };
+  
+    return {
+      ...specialStyles[token.toUpperCase()],
+      ...customStyle
+    };
+  };
 
   return (
     <CDNImg
@@ -33,7 +46,7 @@ const TokenIcon: FunctionComponent<TokenIconProps> = ({
       width={imageDimensions.width}
       src={getTokenIcon(token)}
       alt={token}
-      style={token.toUpperCase() === "STRK" ? { transform: "rotateY(180deg)", ...customStyle } : customStyle}
+      style={getTokenStyle(token, customStyle)}
     />
   );
 };

--- a/components/discover/tokenIcon.tsx
+++ b/components/discover/tokenIcon.tsx
@@ -1,0 +1,41 @@
+import { CDNImg } from "@components/cdn/image";
+import React, { CSSProperties, FunctionComponent, useCallback } from "react";
+
+type TokenIconProps = {
+  token: string;
+  imageDimensions?: {
+    width: number;
+    height: number;
+  };
+  customStyle?: CSSProperties;
+};
+
+const TokenIcon: FunctionComponent<TokenIconProps> = ({
+  token,
+  imageDimensions = {width: 16, height: 16},
+  customStyle = {}
+}) => {
+
+  const getTokenIcon = useCallback((tokenName: string) => {
+    if (tokenName.toUpperCase() === "USDC") return "/icons/usdc.svg";
+    if (tokenName.toUpperCase() === "ETH") return "/icons/eth.svg";
+    if (tokenName.toUpperCase() === "LORDS") return "/icons/lords.webp";
+    if (tokenName.toUpperCase() === "SITH") return "/icons/sith.png";
+    if (tokenName.toUpperCase() === "STRK") return "/icons/strk.webp";
+
+    return "/icons/usdc.svg";
+  }, []);
+
+  return (
+    <CDNImg
+      loading="eager"
+      height={imageDimensions.height}
+      width={imageDimensions.width}
+      src={getTokenIcon(token)}
+      alt={token}
+      style={token.toUpperCase() === "STRK" ? { transform: "rotateY(180deg)", ...customStyle } : customStyle}
+    />
+  );
+};
+
+export default TokenIcon;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

Added flow for claim reward in Earn page

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Feature

Resolves: #868


## Other information
Used the Modal component to build both the claim modal and success popup, as the Popup component lacks some styles customization, making it not that great for mobile viewports.

<!-- any other description of the issue it is solving or anything you'd liek the maintainer to know before reviewing-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `ClaimModal` for users to claim rewards with a responsive design.
	- Added `SuccessModal` to display a confirmation message after claiming rewards.
	- Launched `TokenIcon` for displaying token images with customizable dimensions.

- **Enhancements**
	- Improved `defiTable` functionality with state management for modals related to claims.
	- Enhanced user interaction with clickable areas to trigger modals for claiming rewards.
	- Updated `AppIcon` component for better prop handling and styling options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->