### PR TITLE
Fix: refactor profileCard.tsx margin 

### DIFF
--- a/components/UI/profileCard/profileCard.tsx
+++ b/components/UI/profileCard/profileCard.tsx
@@ -85,11 +85,11 @@ const ProfileCard: FunctionComponent<ProfileCard> = ({
           )}
         </div>
 
-          <div className="flex flex-col h-full justify-between">
+          <div className="flex flex-col h-full justify-center">
             <Typography type={TEXT_TYPE.BODY_SMALL} color="secondary" className={styles.accountCreationDate}>
               {sinceDate ? `${sinceDate}` : ""}
             </Typography>
-            <Typography type={TEXT_TYPE.H2} className={styles.profile_name}>{identity.domain.domain}</Typography>
+            <Typography type={TEXT_TYPE.H2} className={`${styles.profile_name} mt-2`}>{identity.domain.domain}</Typography>
             <div className={styles.address_div}>
             <CopyAddress
                   address={identity?.owner ?? ""}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Refactoring (no functional changes, no API changes)


Resolves: #865 



## Other information

<!-- any other description of the issue it is solving or anything you'd liek the maintainer to know before reviewing-->

Based on @fricoben's suggestion,

In the components/UI/profileCard/profileCard.tsx file, make the following changes:
1. Modify the flex container for the profile information:

From:
```js
<div className="flex flex-col h-full justify-between">
```
To:
```js
<div className="flex flex-col h-full justify-center">
```

2. Add margin to the domain (profile name) Typography component:

From:
```js
<Typography type={TEXT_TYPE.H2} className={styles.profile_name}>{identity.domain.domain}</Typography>
```
To:
```js
<Typography type={TEXT_TYPE.H2} className={`${styles.profile_name} mt-2`}>{identity.domain.domain}</Typography>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visual presentation of the Profile Card component with improved layout and styling.
	- Adjusted alignment and spacing for a more polished user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->