### PR TITLE
fix: boost token

### DIFF
--- a/app/admin/quests/dashboard/[questId]/page.tsx
+++ b/app/admin/quests/dashboard/[questId]/page.tsx
@@ -229,7 +229,7 @@ export default function Page({ params }: QuestIdProps) {
             contract_calls: task.calls,
           },
         };
-      } else if(task.task_type === "custom_api"){
+      } else if (task.task_type === "custom_api") {
         return {
           type: "CustomApi",
           data: {
@@ -239,11 +239,10 @@ export default function Page({ params }: QuestIdProps) {
             api_href: task.href,
             api_url: task.api_url,
             api_cta: task.cta,
-            api_regex: task.regex
-          }
-        }
+            api_regex: task.regex,
+          },
+        };
       }
-
     });
 
     const res = await Promise.all(taskPromises);
@@ -270,6 +269,9 @@ export default function Page({ params }: QuestIdProps) {
         await AdminService.updateBoost({
           ...boostInput,
           hidden: !showBoost,
+          amount: Number(boostInput.amount),
+          num_of_winners: Number(boostInput.num_of_winners),
+          token_decimals: Number(boostInput.token_decimals),
         });
 
         return;
@@ -546,8 +548,7 @@ export default function Page({ params }: QuestIdProps) {
             cta: step.data.contract_cta,
             calls: JSON.parse(step.data.contract_calls),
           });
-        }
-        else if(step.type === "CustomApi"){
+        } else if (step.type === "CustomApi") {
           await AdminService.createCustomApi({
             quest_id: questId.current,
             name: step.data.api_name,
@@ -556,7 +557,7 @@ export default function Page({ params }: QuestIdProps) {
             regex: step.data.api_regex,
             href: step.data.api_href,
             cta: step.data.api_cta,
-          })
+          });
         }
       } catch (error) {
         showNotification(`Error adding ${step.type} task: ${error}`, "error");
@@ -666,7 +667,10 @@ export default function Page({ params }: QuestIdProps) {
             calls: JSON.parse(step.data.contract_calls),
           });
         } catch (error) {
-          showNotification(`Error updating ${step.type} task: ${error}`, "error");
+          showNotification(
+            `Error updating ${step.type} task: ${error}`,
+            "error"
+          );
         }
       } else if (step.type === "CustomApi") {
         await AdminService.updateCustomApi({
@@ -817,7 +821,7 @@ export default function Page({ params }: QuestIdProps) {
         <AdminQuestDetails
           quest={questData}
           // eslint-disable-next-line @typescript-eslint/no-empty-function
-          setShowDomainPopup={() => { }}
+          setShowDomainPopup={() => {}}
           hasRootDomain={false}
           rewardButtonTitle={questData.disabled ? "Enable" : "Disable"}
           onRewardButtonClick={async () => {

--- a/components/admin/formSteps/RewardDetailsForm.tsx
+++ b/components/admin/formSteps/RewardDetailsForm.tsx
@@ -54,18 +54,19 @@ const RewardDetailsForm: FunctionComponent<RewardDetailsFormProps> = ({
 
   const handleBoostTokenChange = useCallback(
     (event: SelectChangeEvent) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const tokenAddress = event.target.value;
+      const tokenName =
+        Object.keys(TOKEN_ADDRESS_MAP[network]).find(
+          (key) => TOKEN_ADDRESS_MAP[network][key] === tokenAddress
+        ) || "";
       setBoostInput((prev: any) => ({
         ...prev,
-        token: event.target.value,
-        // token decimals is a value which has different tokens which we support and use their decimals here
+        token: tokenAddress,
         token_decimals:
-          TOKEN_DECIMAL_MAP[
-            event.target.value as keyof typeof TOKEN_DECIMAL_MAP
-          ],
+          TOKEN_DECIMAL_MAP[tokenName as keyof typeof TOKEN_DECIMAL_MAP],
       }));
     },
-    [setBoostInput]
+    [setBoostInput, network]
   );
 
   return (

--- a/components/admin/formSteps/RewardDetailsForm.tsx
+++ b/components/admin/formSteps/RewardDetailsForm.tsx
@@ -142,7 +142,7 @@ const RewardDetailsForm: FunctionComponent<RewardDetailsFormProps> = ({
             handleChange={handleBoostTokenChange}
             options={Object.keys(TOKEN_ADDRESS_MAP[network]).map((eachItem) => {
               return {
-                value: eachItem,
+                value: TOKEN_ADDRESS_MAP[network][eachItem],
                 label: eachItem,
               };
             })}

--- a/constants/common.ts
+++ b/constants/common.ts
@@ -32,7 +32,7 @@ export const TOP_50_TAB_STRING = "Top 50";
 export const rankOrder = [1, 2, 3];
 export const rankOrderMobile = [1, 2, 3];
 
-export const TOKEN_ADDRESS_MAP = {
+export const TOKEN_ADDRESS_MAP: Record<string, Record<string, string>> = {
   MAINNET: {
     USDC: "0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
     ETH: "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",


### PR DESCRIPTION
# Bugfix

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix

Resolves: #882 



## Context
- The token address is sent instead of the token name
- The token type changes successfully instead of reverting back to "USDC"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced dropdown for selecting boost tokens to display the correct token address based on the selected network.
	- Added new properties (`amount`, `num_of_winners`, `token_decimals`) to boost input handling for improved data processing.

- **Bug Fixes**
	- Corrected the value mapping for dropdown options in the `RewardDetailsForm` component.
	- Refined error handling to ensure consistent number conversion for boost input values.

- **Documentation**
	- Improved type annotation for the `TOKEN_ADDRESS_MAP` constant for better clarity on its structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->