### PR TITLE
fix: Links Map in defi.ts

### DIFF
--- a/utils/defi.ts
+++ b/utils/defi.ts
@@ -46,6 +46,9 @@ const linkMap: { [key: string]: { [key: string]: string } } = {
   opus: {
     Strategies: "https://app.opus.money/",
   },
+  haiko_solvers: {
+    "Provide Liquidity": "https://app.haiko.xyz/positions",
+  },
 };
 
 export const getRedirectLink = (appName: string, actionType: string) => {


### PR DESCRIPTION
# Bug Fix

- Bugfix

Resolves: #888

## Haiko Solvers
Providing haiko_solvers in the linkMap resolves the issue of some protocol links not redirecting to liquidity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new link for the "Provide Liquidity" action in the `haiko_solvers` application, enhancing user navigation to the relevant section.
  
- **Bug Fixes**
	- No bug fixes were implemented in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->