### PR TITLE
fix: quest data not properly reloaded

### DIFF
--- a/app/quest/[questPage]/quest.tsx
+++ b/app/quest/[questPage]/quest.tsx
@@ -54,8 +54,7 @@ const Quest: FunctionComponent<QuestPageProps> = ({
     }
   }, []);
 
-  // this fetches quest data
-  useEffect(() => {
+  const fetchQuestData = useCallback(async () => {
     getQuestById(questId)
       .then((data) => {
         if (!data) {
@@ -77,6 +76,11 @@ const Quest: FunctionComponent<QuestPageProps> = ({
           setErrorPageDisplay(true);
         }
       });
+  }, [questId]);
+
+  useEffect(() => {
+    if (!questId) return;
+    fetchQuestData();
   }, [questId]);
 
   useEffect(() => {
@@ -147,6 +151,7 @@ const Quest: FunctionComponent<QuestPageProps> = ({
           setShowDomainPopup={setShowDomainPopup}
           hasRootDomain={hasRootDomain}
           hasNftReward={hasNftReward}
+          fetchQuestData={fetchQuestData}
         />
       </div>
     </>

--- a/components/quests/task.tsx
+++ b/components/quests/task.tsx
@@ -32,6 +32,7 @@ const Task: FunctionComponent<Task> = ({
   hasRootDomain,
   customError,
   expired,
+  checkUserRewards,
 }) => {
   const [isClicked, setIsClicked] = useState(false);
   const [isVerified, setIsVerified] = useState(false);
@@ -89,12 +90,14 @@ const Task: FunctionComponent<Task> = ({
           await new Promise((resolve) =>
             setTimeout(() => {
               setIsVerified(true);
+              if (checkUserRewards) checkUserRewards();
               setIsLoading(false);
               resolve(null);
             }, timeout)
           );
         } else {
           setIsVerified(true);
+          if (checkUserRewards) checkUserRewards();
           setIsLoading(false);
         }
       } catch (error) {


### PR DESCRIPTION
Quest data were not properly reloaded when completing a task, so when the last task didn't involve refreshing the page (i.e. twitter tasks), the "Get Reward" button stayed grayed out
![image](https://github.com/user-attachments/assets/5bbdbbf9-88f4-45d5-bab3-eb97432e0219)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced quest data fetching in the `Quest` component for improved reliability.
	- Added a new prop to `QuestDetails` for better integration with quest data fetching.
	- Introduced a new prop in the `Task` component to handle user rewards upon task verification.

- **Bug Fixes**
	- Improved error handling for fetching quest data and user rewards.

- **Refactor**
	- Streamlined data-fetching logic using `useCallback` for better performance and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->