### PR TITLE
Add skeleton for portfolio value sum

### DIFF
--- a/components/UI/profileCard/profileCard.tsx
+++ b/components/UI/profileCard/profileCard.tsx
@@ -29,7 +29,6 @@ import Typography from "../typography/typography";
 import { calculateTotalBalance } from "../../../services/argentPortfolioService";
 import Avatar from "../avatar";
 import { useHidePortfolio } from "@hooks/useHidePortfolio";
-import Loading from '@components/skeletons/loading';
 
 const MAX_RETRIES = 1000;
 const RETRY_DELAY = 2000;
@@ -166,8 +165,16 @@ const ProfileCard: FunctionComponent<ProfileCardProps> = ({
           </Typography>
           <div className={styles.address_div}>
             <div className='flex items-center gap-2 h-6'>
-                  <Loading isLoading={totalBalance === null}>
-                   <Typography
+            {totalBalance === null?
+            <Skeleton
+            variant='text'
+            sx={{ bgcolor: "grey.600" }}
+            width={60}
+            height={30}
+          />
+            :
+            <>
+               <Typography
                 type={TEXT_TYPE.BODY_SMALL}
                 className={`${styles.wallet_amount} font-extrabold`}
               >
@@ -185,15 +192,14 @@ const ProfileCard: FunctionComponent<ProfileCardProps> = ({
                   />
                 )}
               </Typography>
-                  </Loading>
-                <Loading isLoading={totalBalance === null} loadingType='spinner'>
-                <div
+              <div
                   onClick={() => setHidePortfolio(!hidePortfolio)}
                   className='cursor-pointer'
                 >
                   {hidePortfolio ? <EyeIconSlashed /> : <EyeIcon />}
                 </div>
-                </Loading>
+            </>  
+          }   
             </div>
           </div>
           <div className='flex sm:hidden justify-center py-4'>

--- a/components/UI/profileCard/profileCard.tsx
+++ b/components/UI/profileCard/profileCard.tsx
@@ -165,7 +165,7 @@ const ProfileCard: FunctionComponent<ProfileCardProps> = ({
             {identity.domain?.domain || 'Unknown Domain'}
           </Typography>
           <div className={styles.address_div}>
-            <div className='flex items-center gap-2'>
+            <div className='flex items-center gap-2 h-6'>
                   <Loading isLoading={totalBalance === null}>
                    <Typography
                 type={TEXT_TYPE.BODY_SMALL}
@@ -185,13 +185,15 @@ const ProfileCard: FunctionComponent<ProfileCardProps> = ({
                   />
                 )}
               </Typography>
-              <div
-                onClick={() => setHidePortfolio(!hidePortfolio)}
-                className='cursor-pointer'
-              >
-                {hidePortfolio ? <EyeIconSlashed /> : <EyeIcon />}
-              </div>
                   </Loading>
+                <Loading isLoading={totalBalance === null} loadingType='spinner'>
+                <div
+                  onClick={() => setHidePortfolio(!hidePortfolio)}
+                  className='cursor-pointer'
+                >
+                  {hidePortfolio ? <EyeIconSlashed /> : <EyeIcon />}
+                </div>
+                </Loading>
             </div>
           </div>
           <div className='flex sm:hidden justify-center py-4'>

--- a/components/UI/profileCard/profileCard.tsx
+++ b/components/UI/profileCard/profileCard.tsx
@@ -29,6 +29,7 @@ import Typography from "../typography/typography";
 import { calculateTotalBalance } from "../../../services/argentPortfolioService";
 import Avatar from "../avatar";
 import { useHidePortfolio } from "@hooks/useHidePortfolio";
+import Loading from '@components/skeletons/loading';
 
 const MAX_RETRIES = 1000;
 const RETRY_DELAY = 2000;
@@ -165,7 +166,8 @@ const ProfileCard: FunctionComponent<ProfileCardProps> = ({
           </Typography>
           <div className={styles.address_div}>
             <div className='flex items-center gap-2'>
-              <Typography
+                  <Loading isLoading={totalBalance === null}>
+                   <Typography
                 type={TEXT_TYPE.BODY_SMALL}
                 className={`${styles.wallet_amount} font-extrabold`}
               >
@@ -173,7 +175,7 @@ const ProfileCard: FunctionComponent<ProfileCardProps> = ({
                   hidePortfolio ? (
                     '******'
                   ) : (
-                    `$${totalBalance.toFixed(2)}`
+                    `$${totalBalance?.toFixed(2)}`
                   )
                 ) : (
                   <Skeleton
@@ -189,6 +191,7 @@ const ProfileCard: FunctionComponent<ProfileCardProps> = ({
               >
                 {hidePortfolio ? <EyeIconSlashed /> : <EyeIcon />}
               </div>
+                  </Loading>
             </div>
           </div>
           <div className='flex sm:hidden justify-center py-4'>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4471,6 +4471,7 @@
     },
     "node_modules/@parcel/watcher-wasm/node_modules/napi-wasm": {
       "version": "1.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:
A skeleton loader for the portfolio value sum to address the loading delay issue was added 

- Bugfix

Resolves: #936 



## Other information

<!-- any other description of the issue it is solving or anything you'd liek the maintainer to know before reviewing-->
i make use of the loading component in the project file, the loading component has two type of loading component 
1- A spinner and
2- A skeleton 

i try using the spinner but i noticed it makes the ui to look more buggy but it has a better indication for a loading feature but due to the ui  issue i end up using the skeleton type (loading) which looks much more better
if you want more modification to this please let me know



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a loading indicator for the user's total balance in the ProfileCard component.
	- The balance display now shows a loading state when data is being fetched, enhancing user feedback.

- **Bug Fixes**
	- Improved user experience by ensuring the balance is only displayed when available, preventing potential confusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->