### PR TITLE
Fix: Rename earn to DeFi in navigation bar

### DIFF
--- a/components/UI/navbar.tsx
+++ b/components/UI/navbar.tsx
@@ -211,7 +211,7 @@ const Navbar: FunctionComponent = () => {
                 <li className={styles.menuItem}>Quests</li>
               </Link>
               <Link href={`/discover/defi`}>
-                <li className={styles.menuItem}>Earn</li>
+                <li className={styles.menuItem}>DeFi</li>
               </Link>
               {isConnected && (
                 <Link href={`/${address}`}>
@@ -286,7 +286,7 @@ const Navbar: FunctionComponent = () => {
                       onClick={() => setNav(false)}
                       className={styles.menuItemSmall}
                     >
-                      Earn
+                      DeFi
                     </li>
                   </Link>
                   {isConnected && (


### PR DESCRIPTION
- Code style update (formatting, renaming)


Resolves: #952 



## Other information

kindly review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the "Earn" menu item to "DeFi" in both desktop and mobile navigation of the Navbar component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->