### PR TITLE
Fix: Redirect to quest dashboard using router.push and remove handlePagination

### DIFF
--- a/app/admin/quests/create/page.tsx
+++ b/app/admin/quests/create/page.tsx
@@ -247,11 +247,16 @@ export default function Page() {
     setButtonLoading(true);
     const id = await handleCreateQuest();
     if (!id) return;
+
     await handleCreateBoost(id);
     await handleCreateNftUri(id);
-    await setButtonLoading(false);
-    handlePagination("Next");
-  }, [questInput, boostInput, nfturi]);
+
+    setButtonLoading(false);
+
+    // Redirect to the quest dashboard using the quest ID
+    router.push(`/admin/quests/dashboard/${id}?tab=tasks`);
+}, [questInput, boostInput, nfturi, router]);
+
 
   const handleCreateTask = useCallback(async () => {
     if (isSaving.current) return;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Redirect the admin after quest creation

Resolves: #1021



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced quest creation workflow with automatic redirection to quest dashboard upon successful quest, boost, and NFT URI creation.

- **User Experience**
	- Improved navigation flow after completing quest creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->