### PR TITLE
Replace Enable/Disable button with Analytics button in quest dashboard

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
   "parser": "@typescript-eslint/parser",
   "rules": {
     "@next/next/no-img-element": "off",
-    "@next/next/no-document-import-in-page": "off"
+    "@next/next/no-document-import-in-page": "off",
+    "@typescript-eslint/no-empty-function": "off"
   },
   "overrides": [
     {

--- a/app/admin/quests/dashboard/[questId]/page.tsx
+++ b/app/admin/quests/dashboard/[questId]/page.tsx
@@ -823,15 +823,10 @@ export default function Page({ params }: QuestIdProps) {
           // eslint-disable-next-line @typescript-eslint/no-empty-function
           setShowDomainPopup={() => {}}
           hasRootDomain={false}
-          rewardButtonTitle={questData.disabled ? "Enable" : "Disable"}
-          onRewardButtonClick={async () => {
-            await handlePublishQuest(!questData.disabled);
-            if (!questData.disabled) {
-              showNotification("Quest is disabled from launch", "success");
-            } else {
-              showNotification("Quest is enabled for launch", "success");
-            }
-            await fetchPageData();
+          rewardButtonTitle="Analytics"
+          onRewardButtonClick={() => {
+            const analyticsUrl = `/analytics/${questData.id}`;
+            window.open(analyticsUrl, "_blank");
           }}
           overrideDisabledState={false}
           isEdit={true}

--- a/app/admin/quests/dashboard/[questId]/page.tsx
+++ b/app/admin/quests/dashboard/[questId]/page.tsx
@@ -820,7 +820,6 @@ export default function Page({ params }: QuestIdProps) {
       return (
         <AdminQuestDetails
           quest={questData}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           setShowDomainPopup={() => {}}
           hasRootDomain={false}
           rewardButtonTitle="Analytics"


### PR DESCRIPTION
## Changes Made
- Changed the rewardButtonTitle from a conditional "Enable"/"Disable" to a static "Analytics"
- Updated the onRewardButtonClick handler to open analytics page in a new tab
- Removed the quest enable/disable functionality
- Added functionality to open analytics/${questData.id} in a new tab

## Testing
- Verified that the Analytics button appears correctly
- Confirmed that clicking the button opens the analytics page in a new tab

Closes #1016

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an analytics button for quests that opens a dedicated analytics page
- **User Experience**
  - Replaced quest enable/disable functionality with direct analytics access
  - Simplified quest management interface navigation
- **Chores**
  - Updated ESLint configuration to allow empty functions without warnings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->