### PR TITLE
Fix: Update featured quest logic to prioritize recent quests

### DIFF
--- a/context/QuestsProvider.tsx
+++ b/context/QuestsProvider.tsx
@@ -133,24 +133,26 @@ export const QuestsContextProvider = ({
 
     const notExpired = quests.filter((quest) => !quest.expired);
     const lastBoostedQuest = boostedQuests.length
-        ? quests.find(
-            (quest) =>
-                quest.id === boostedQuests[boostedQuests.length - 1] &&
-                !quest.expired
-          )
-        : undefined;
+      ? quests.find(
+          (quest) =>
+            quest.id === boostedQuests[boostedQuests.length - 1] &&
+            !quest.expired
+        )
+      : undefined;
 
     const recentQuest = notExpired.find(
-        (quest) =>
-            new Date(quest.start_timestamp) >= new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) // Check if less than a week ago
+      (quest) =>
+        quest.start_timestamp &&
+        new Date(quest.start_timestamp) >=
+          new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) // Check if less than a week ago
     );
 
     setFeaturedQuest(
-        lastBoostedQuest ||
+      lastBoostedQuest ||
         recentQuest ||
         notExpired[Math.floor(Math.random() * notExpired.length)]
     );
-}, [quests, boostedQuests]);
+  }, [quests, boostedQuests]);
 
   const contextValues = useMemo(() => {
     return {

--- a/context/QuestsProvider.tsx
+++ b/context/QuestsProvider.tsx
@@ -130,19 +130,27 @@ export const QuestsContextProvider = ({
 
   useMemo(() => {
     if (!quests.length) return;
+
     const notExpired = quests.filter((quest) => !quest.expired);
     const lastBoostedQuest = boostedQuests.length
-      ? quests.find(
-          (quest) =>
-            quest.id === boostedQuests[boostedQuests.length - 1] &&
-            !quest.expired
-        )
-      : undefined;
+        ? quests.find(
+            (quest) =>
+                quest.id === boostedQuests[boostedQuests.length - 1] &&
+                !quest.expired
+          )
+        : undefined;
+
+    const recentQuest = notExpired.find(
+        (quest) =>
+            new Date(quest.start_timestamp) >= new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) // Check if less than a week ago
+    );
+
     setFeaturedQuest(
-      lastBoostedQuest ||
+        lastBoostedQuest ||
+        recentQuest ||
         notExpired[Math.floor(Math.random() * notExpired.length)]
     );
-  }, [quests, boostedQuests]);
+}, [quests, boostedQuests]);
 
   const contextValues = useMemo(() => {
     return {


### PR DESCRIPTION
Updated the code in context/QuestsProvider.tsx with the following logic:

- Filter quests with start_timestamp less than a week ago.

- Update the fallback condition to prioritize such quests if no boosted quest is available.


Close #1011 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced quest selection logic to highlight recently started quests
  - Improved featured quest selection mechanism
- **Refactor**
  - Optimized code formatting and conditional checks within quest filtering logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->