### PR TITLE
Fix: Sort quests by ID in descending order

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -17,14 +17,26 @@ export default function Page() {
   const { address } = useAccount();
   const [loading, setLoading] = useState<boolean>(true);
 
-  const [quests, setQuests] = useState<QuestList>({} as QuestList);
+  const [quests, setQuests] = useState<QuestDocument[]>([]);
 
   const fetchQuests = useCallback(async () => {
     try {
       setLoading(true);
       const res = (await getQuests()) || {};
-      setQuests(res);
+
+      let allQuests: QuestDocument[] = [];
+      Object.keys(res).forEach((category) => {
+        const categoryQuests = res[category]; 
+        if (Array.isArray(categoryQuests)) {
+          allQuests = allQuests.concat(categoryQuests);
+        }
+      });
+
+      const sortedAllQuests = allQuests.sort((a, b) => b.id - a.id);
+
+      setQuests(allQuests);
       setLoading(false);
+
     } catch (error) {
       console.log("Error while fetching quests", error);
     }
@@ -33,7 +45,6 @@ export default function Page() {
   useEffect(() => {
     fetchQuests();
   }, [address]);
-
   return (
     <div className={styles.container}>
       <div className={styles.backButton}>
@@ -50,31 +61,21 @@ export default function Page() {
         {loading ? (
           <FeaturedQuestSkeleton />
         ) : (
-          (Object.keys(quests) as (keyof typeof quests)[]).map(
-            (categoryName: keyof typeof quests) => {
-              const categoryValue = quests[categoryName];
-              if (Array.isArray(categoryValue)) {
-                return categoryValue.map((quest: QuestDocument) => {
-                  return (
-                    <Quest
-                      key={quest.id}
-                      title={quest.title_card}
-                      onClick={() => router.push(`/analytics/${quest.id}`)}
-                      imgSrc={quest.img_card}
-                      issuer={{
-                        name: quest.issuer,
-                        logoFavicon: quest.logo,
-                      }}
-                      reward={quest.rewards_title}
-                      id={quest.id}
-                      expired={false}
-                    />
-                  );
-                });
-              }
-              return null;
-            }
-          )
+          quests.map((quest) => (
+            <Quest
+              key={quest.id}
+              title={quest.title_card}
+              onClick={() => router.push(`/analytics/${quest.id}`)}
+              imgSrc={quest.img_card}
+              issuer={{
+                name: quest.issuer,
+                logoFavicon: quest.logo,
+              }}
+              reward={quest.rewards_title}
+              id={quest.id}
+              expired={false}
+            />
+          ))
         )}
       </div>
     </div>

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -34,7 +34,7 @@ export default function Page() {
 
       const sortedAllQuests = allQuests.sort((a, b) => b.id - a.id);
 
-      setQuests(allQuests);
+      setQuests(sortedAllQuests);
       setLoading(false);
 
     } catch (error) {


### PR DESCRIPTION
# Bugfix

Resolves: #1014

Quests are sorted by ID in descending order, ensuring the most recent quests appear first. Previously, the application grouped quests by category and displayed them in the order they were retrieved.

# Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved quest management and rendering in the analytics page
- **Refactor**
	- Simplified quest data structure from nested object to flat array
	- Streamlined quest fetching and sorting process
<!-- end of auto-generated comment: release notes by coderabbit.ai -->