### PR TITLE
Fix: Quiz title style

### DIFF
--- a/components/quiz/screenLayout.tsx
+++ b/components/quiz/screenLayout.tsx
@@ -18,7 +18,7 @@ const ScreenLayout: FunctionComponent<ScreenLayoutProps> = ({
 }) => {
   return (
     <div className={styles.menu}>
-      <Typography type={TEXT_TYPE.H1} className={highlightTitle ? "title extrabold" : styles.menuTitle}>
+      <Typography type={TEXT_TYPE.H1} className={highlightTitle ? "title quiz extrabold" : styles.menuTitle}>
         {title}
       </Typography>
       {children}

--- a/styles/components/typography.module.css
+++ b/styles/components/typography.module.css
@@ -61,7 +61,8 @@
 .typography-body-small {
   font-family: "Sora", sans-serif;
   font-size: 14px;
-  line-height: 20px;
+  font-weight: 400;
+  line-height: 25px;
   letter-spacing: 0;
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -72,6 +72,12 @@ a {
   color: transparent;
 }
 
+.title.quiz {
+  color: var(--secondary);
+  background: transparent;
+  -webkit-text-fill-color: var(--secondary);
+}
+
 .title.extrabold {
   font-family: "Sora-ExtraBold";
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

# Pull Request type

This pull request updates the styling of the quiz title to enhance its appearance without affecting global styles.

Please add the labels corresponding to the type of changes your PR introduces:

- Code style update (formatting, renaming)

Resolves: #1045 

## Other information

The changes involve modifying the styles specifically for the quiz title within the relevant component files, such as `screenLayout.tsx` and `typography.module.css`. The adjustments ensure that the title is visually distinct and aligns with the overall design of the quiz feature while maintaining the integrity of the global styles. This update aims to improve the user interface and provide a better user experience without unintended side effects on other components.

## Evidence

- before:

![image](https://github.com/user-attachments/assets/174e977d-3337-44d0-9d92-f4a43a378c5a)


- after:

![image](https://github.com/user-attachments/assets/723799a3-e1f2-4ece-ae2f-7993e3893c50)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated quiz title styling for a more distinctive visual appearance when highlighted.
  - Enhanced small text readability with increased spacing and adjusted font weight.
  - Introduced a new quiz-themed style that applies a secondary color and a transparent background for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->