### PR TITLE
feat: make main cards clickable with hover effect

### DIFF
--- a/components/discover/defiOpportunityCard.tsx
+++ b/components/discover/defiOpportunityCard.tsx
@@ -19,6 +19,7 @@ interface PoolCardProps {
   };
   token1Icon?: string;
   token2Icon?: string;
+  onClick?: () => void;
 }
 
 export default function DefiOpportunityCardComponent({
@@ -33,9 +34,10 @@ export default function DefiOpportunityCardComponent({
   },
   token1Icon,
   token2Icon,
+  onClick,
 }: PoolCardProps) {
   return (
-    <div className="w-full bg-[#1F1F25] py-4 rounded-lg mt-6 lg:mt-0 _border _box-shadow">
+    <div onClick={onClick} className="w-full bg-[#1F1F25] hover:bg-white/40 transition-colors py-4 rounded-lg mt-6 lg:mt-0 _border _box-shadow modified-cursor-pointer">
       <div className="w-full flex justify-between items-start mb-2 relative px-4">
         <div>
           <h2 className="text-[18px] md:text-[14px] xl:text-[24px] font-[700] text-white mb-1">

--- a/components/discover/defiTable.tsx
+++ b/components/discover/defiTable.tsx
@@ -453,6 +453,10 @@ const DataTable: FunctionComponent<DataTableProps> = ({ data, loading }) => {
                 token2Icon={getTokenIcon(
                   parseTokenPair(opportunity.title.toLowerCase()).second
                 )}
+                onClick={() => window.open(
+                  getRedirectLink(opportunity.app, opportunity.action),
+                  "_blank"
+                )}
               />
             ))}
           </div>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Made the three main cards clickable, redirecting them to their corresponding pool.
Used the same links as the first three in the table for consistency.
Added the same hover card effect as seen on other cards across the site.
Close #1023 



# Pull Request type
feature→ For new features or enhancements. 
<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please add the labels corresponding to the type of changes your PR introduces:

- Bugfix
- Feature
- Code style update (formatting, renaming)
- Refactoring (no functional changes, no API changes)
- Build-related changes
- Documentation content changes
- Testing
- Other (please describe):

Resolves: #NA



## Other information

<!-- any other description of the issue it is solving or anything you'd liek the maintainer to know before reviewing-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Opportunity cards now respond to click events with enhanced visual feedback.
  - Clicking a card opens a related page in a new tab, offering streamlined navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->