### PR TITLE
Fix: prevent scroll shift by maintaining table height during loading

### DIFF
--- a/components/discover/defiTableSkeleton.tsx
+++ b/components/discover/defiTableSkeleton.tsx
@@ -11,28 +11,28 @@ import { TEXT_TYPE } from "@constants/typography";
 const DefiTableSkeleton: React.FC = () => {
   return (
     <div className="w-full overflow-x-auto">
-      <div className="rounded-xl border-[1px] border-[#f4faff4d] min-w-[930px] xl:w-full">
+      <div className=" border-[1px] border-[#f4faff4d] min-w-[930px] xl:w-full">
         <Table>
           <TableBody>
             {Array.from({ length: 10 }).map((_, index) => (
               <TableRow key={index} className="animate-pulse">
                 <TableCell>
-                  <div className="h-8 w-full bg-gray-300 rounded-md" />
+                  <div className="h-[2.525rem] bg-gray-300 rounded-md" />
                 </TableCell>
                 <TableCell>
-                  <div className="h-8 bg-gray-300 rounded-md" />
+                  <div className="h-[2.525rem] bg-gray-300 rounded-md" />
                 </TableCell>
                 <TableCell>
-                  <div className="h-8 bg-gray-300 rounded-md" />
+                  <div className="h-[2.525rem] bg-gray-300 rounded-md" />
                 </TableCell>
                 <TableCell>
-                  <div className="h-8 bg-gray-300 rounded-md" />
+                  <div className="h-[2.525rem] bg-gray-300 rounded-md" />
                 </TableCell>
                 <TableCell>
-                  <div className="h-8 bg-gray-300 rounded-md" />
+                  <div className="h-[2.525rem] bg-gray-300 rounded-md" />
                 </TableCell>
                 <TableCell>
-                  <div className="h-8 bg-gray-300 rounded-md" />
+                  <div className="h-[2.525rem] bg-gray-300 rounded-md" />
                 </TableCell>
               </TableRow>
             ))}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Close #1173 

<!-- any other description of the issue it is solving or anything you'd like the maintainer to know before reviewing-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the visual appearance of the skeleton loader in the DeFi table by removing rounded corners and adjusting the height and width of placeholder elements for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->