### PR TITLE
#1175 banner details form

### DIFF
--- a/components/admin/formSteps/BannerDetailsForm.tsx
+++ b/components/admin/formSteps/BannerDetailsForm.tsx
@@ -2,6 +2,8 @@ import React, { FunctionComponent } from "react";
 import TextInput from "../textInput";
 import { UpdateQuest } from "../../../types/backTypes";
 import Button from "@components/UI/button";
+import { AdminService } from "@services/authService";
+import { useNotification } from "@context/NotificationProvider";
 
 type BannerDetailsFormProps = {
   questInput: UpdateQuest;
@@ -13,10 +15,13 @@ type BannerDetailsFormProps = {
 
 const BannerDetailsForm: FunctionComponent<BannerDetailsFormProps> = ({
   questInput,
+  setQuestInput,
   handleQuestInputChange,
   onSubmit,
   submitButtonDisabled,
 }) => {
+  const { showNotification } = useNotification();
+
   return (
     <div className="flex flex-col gap-4">
       <TextInput
@@ -54,13 +59,53 @@ const BannerDetailsForm: FunctionComponent<BannerDetailsFormProps> = ({
         label="Link"
         placeholder="Enter Link"
       />
-      <TextInput
-        name="banner.image"
-        value={questInput.banner?.image || ""}
-        onChange={handleQuestInputChange}
-        label="Image URL"
-        placeholder="Enter Image URL"
-      />
+      <div className="flex flex-col gap-5">
+        <TextInput
+          name="banner.image"
+          value={questInput.banner?.image || ""}
+          onChange={handleQuestInputChange}
+          label="Image URL"
+          placeholder="Enter Image URL"
+        />
+        <input
+          type="file"
+          name="banner_image_file"
+          accept=".webp"
+          className="border border-[#f4faff4d] rounded-lg p-2 w-80"
+          onChange={async (event) => {
+            const file = event.target.files?.[0];
+            if (!file) {
+              return;
+            }
+            if (!file.type.includes('webp')) {
+              showNotification("Only .webp files are allowed", "error");
+              return;
+            }
+            const imageName = `${questInput.id}_banner`;
+            const imageUrl = `${process.env.NEXT_PUBLIC_API_LINK}/images/${imageName}`;
+            try {
+              await AdminService.uploadImage(file, imageName);
+              setQuestInput((prev) => ({
+                ...prev,
+                banner: {
+                  tag: prev.banner?.tag || "",
+                  title: prev.banner?.title || "",
+                  description: prev.banner?.description || "",
+                  cta: prev.banner?.cta || "",
+                  href: prev.banner?.href || "",
+                  image: imageUrl,
+                },
+              }));
+              showNotification("Banner image uploaded successfully", "success");
+            } catch (err) {
+              showNotification(
+                err instanceof Error ? err.message : "Failed to upload banner image",
+                "error"
+              );
+            }
+          }}
+        />
+      </div>
       <div className="w-full sm:w-fit">
         <Button onClick={onSubmit} disabled={submitButtonDisabled}>
           <p>Save Changes</p>


### PR DESCRIPTION
## Summary

  Added file input field for banner image upload in the quest creation/editing admin dashboard. This allows
  administrators to upload .webp banner images directly through the UI, following the same pattern as the
  existing reward step image upload functionality.

  ## Changes Made

  - **Enhanced BannerDetailsForm component** (`components/admin/formSteps/BannerDetailsForm.tsx`)
    - Added file input field next to existing Image URL field
    - Implemented image upload logic using `AdminService.uploadImage()`
    - Added .webp file type restriction with client-side validation
    - Auto-populates Image URL field upon successful upload
    - Names uploaded images using format `<quest_id>_banner`
    - Added proper error handling and success/error notifications

## Pull Request type

- Feature

Resolves: #1175 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to upload a `.webp` banner image file directly within the Banner Details form.
  * Users now receive notifications for successful uploads or errors during the upload process.

* **Enhancements**
  * Improved form layout by grouping the image URL input and file upload option together for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->